### PR TITLE
Update 00_introduction.ipynb 

### DIFF
--- a/tutorials/00_introduction.ipynb
+++ b/tutorials/00_introduction.ipynb
@@ -541,7 +541,7 @@
     "\n",
     "To distinguish between the optimization done by the Theseus optimizers, and those done outside the Theseus optimizers (e.g., by PyTorch's autograd during learning), we will refer to them as *inner loop optimization* and *outer loop optimization* respectively. Note that the inner loop optimization optimizes only the optimization variables, and the outer loop optimization can optimize only (selected) auxiliary variables provided to the PyTorch autograd optimizers. A call to `TheseusLayer` `forward()` performs only inner loop optimization; typically the PyTorch autograd learning steps will perform the outer loop optimizations. We will see examples of this in the following tutorials.\n",
     "\n",
-    "Any updates to the auxiliary variables during the learning loop are best done via the `forward` method of the `TheseusLayer`. While variables and objectives can be updated independently without going through the `TheseusLayer`, this may result in an error during optimization, depending on the states of the internal data structures. Therefore, we recommend that any updates during learning be performed only via the `TheseusLayer`."
+    "Any updates to the optimization variables during the learning loop are best done via the `forward` method of the `TheseusLayer`. While variables and objectives can be updated independently without going through the `TheseusLayer`, this may result in an error during optimization, depending on the states of the internal data structures. Therefore, we recommend that any updates during learning be performed only via the `TheseusLayer`."
    ]
   }
  ],


### PR DESCRIPTION
I feel like you wrote it wrong by mistake, optimization variables are optimized by forward pass, while auxiliary variables are fixed during forward pass and then optimized by pytorch. 
