### PR TITLE
Forced Gauss-Newton step for last iterations of truncated backward.

### DIFF
--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -180,6 +180,11 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
             self.linear_solver.linearization.linearize()
             try:
                 if truncated_grad_loop:
+                    # The derivation for implicit differentiation states that
+                    # the autograd-enabled loop (which `truncated_grad_loop` signals)
+                    # must be done using Gauss-Newton steps. Well, technically,
+                    # full Newton, but it seems less stable numerically and
+                    # GN is working well so far.
                     delta = self.linear_solver.solve()
                 else:
                     delta = self.compute_delta(**kwargs)

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -179,7 +179,10 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
             # do optimizer step
             self.linear_solver.linearization.linearize()
             try:
-                delta = self.compute_delta(**kwargs)
+                if truncated_grad_loop:
+                    delta = self.linear_solver.solve()
+                else:
+                    delta = self.compute_delta(**kwargs)
             except RuntimeError as run_err:
                 msg = (
                     f"There was an error while running the linear optimizer. "


### PR DESCRIPTION
## Motivation and Context
Our current derivation of implicit/truncated backward modes hols only for Gauss-Newton. However, regardless of the optimization method used, we can first find the fixed point, then force the optimizer to apply a GN step. Preliminary experiments with Levenberg-Marquardt show that this improves the error in gradient computation, compared with numerical derivatives. 

Marking as bugfix, since this means that previous version of LM was incorrect. 


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
