### PR TITLE
Updated README with libsuitesparse installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The current focus is on nonlinear least squares with support for sparsity, batch
 - Prerequisites
     - We *strongly* recommend you install `theseus` in a venv or conda environment.
     - Theseus requires `torch` installation. To install for your particular CPU/CUDA configuration, follow the instructions in the PyTorch [website](https://pytorch.org/get-started/locally/).
+    - Theseus also requires `suitesparse`, which you can install via:
+        - `sudo apt-get install libsuitesparse-dev` (Ubuntu).
+        - `conda install -c conda-forge suitesparse` (Mac).
     
 - Installing
     ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The current focus is on nonlinear least squares with support for sparsity, batch
 - Prerequisites
     - We *strongly* recommend you install `theseus` in a venv or conda environment.
     - Theseus requires `torch` installation. To install for your particular CPU/CUDA configuration, follow the instructions in the PyTorch [website](https://pytorch.org/get-started/locally/).
-    - Theseus also requires `suitesparse`, which you can install via:
+    - Theseus also requires [`suitesparse`](https://people.engr.tamu.edu/davis/suitesparse.html), which you can install via:
         - `sudo apt-get install libsuitesparse-dev` (Ubuntu).
         - `conda install -c conda-forge suitesparse` (Mac).
     


### PR DESCRIPTION
## Motivation and Context
pip installation fails if libsuitesparse is not pre-installed. 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Installation works on new environments in Mac and collab notebook if the steps in the new README are followed.
