### PR TITLE
Fixed bug in Variable.update() that was breaking torch graph...

### DIFF
--- a/theseus/core/variable.py
+++ b/theseus/core/variable.py
@@ -56,8 +56,8 @@ class Variable:
                 f"{self.name} has dtype {self.dtype}."
             )
         if batch_ignore_mask is not None and batch_ignore_mask.any():
-            good_indices = ~batch_ignore_mask
-            self[good_indices] = data[good_indices]
+            mask_shape = (-1,) + (1,) * (data.ndim - 1)
+            self.data = torch.where(batch_ignore_mask.view(mask_shape), self.data, data)
         else:
             self.data = data
 


### PR DESCRIPTION
…when batch_ignore_mask.any() == True.

## Motivation and Context
This was causing backward errors in @maurimo's notebook whenever there were batch elements that converged before others. Not sure why we hadn't seen this error before, since I think some of our test had elements converging at different rates (but not 100% sure). cc: @fantaosha who was also looking into this notebook today.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Maurizio's notebook now runs w/o the torch errors in backward pass. 

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
