### PR TITLE
Added error handling for missing `matplotlib` and `omegaconf` installation when using `theg`

### DIFF
--- a/theseus/utils/examples/__init__.py
+++ b/theseus/utils/examples/__init__.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 
 try:
     from .motion_planning import (
@@ -13,7 +14,7 @@ try:
         generate_trajectory_figs,
     )
 except ModuleNotFoundError:
-    print(
+    warnings.warn(
         "Unable to import Motion Planning utilities. "
         "Please make sure you have matplotlib installed."
     )
@@ -35,7 +36,7 @@ try:
         visualize_tactile_push2d,
     )
 except ModuleNotFoundError:
-    print(
+    warnings.warn(
         "Unable to import Tactile Pose Estimation utilities. "
         "Please make sure you have matplotlib and omegaconf installed."
     )

--- a/theseus/utils/examples/__init__.py
+++ b/theseus/utils/examples/__init__.py
@@ -3,26 +3,39 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .motion_planning import (
-    InitialTrajectoryModel,
-    MotionPlanner,
-    ScalarCollisionWeightAndCostEpstModel,
-    ScalarCollisionWeightModel,
-    TrajectoryDataset,
-    generate_trajectory_figs,
-)
-from .tactile_pose_estimation import (
-    TactileMeasModel,
-    TactilePoseEstimator,
-    TactilePushingDataset,
-    TactileWeightModel,
-    create_tactile_models,
-    get_tactile_cost_weight_inputs,
-    get_tactile_initial_optim_vars,
-    get_tactile_motion_capture_inputs,
-    get_tactile_nn_measurements_inputs,
-    get_tactile_poses_from_values,
-    init_tactile_model_from_file,
-    update_tactile_pushing_inputs,
-    visualize_tactile_push2d,
-)
+try:
+    from .motion_planning import (
+        InitialTrajectoryModel,
+        MotionPlanner,
+        ScalarCollisionWeightAndCostEpstModel,
+        ScalarCollisionWeightModel,
+        TrajectoryDataset,
+        generate_trajectory_figs,
+    )
+except ModuleNotFoundError:
+    print(
+        "Unable to import Motion Planning utilities. "
+        "Please make sure you have matplotlib installed."
+    )
+
+try:
+    from .tactile_pose_estimation import (
+        TactileMeasModel,
+        TactilePoseEstimator,
+        TactilePushingDataset,
+        TactileWeightModel,
+        create_tactile_models,
+        get_tactile_cost_weight_inputs,
+        get_tactile_initial_optim_vars,
+        get_tactile_motion_capture_inputs,
+        get_tactile_nn_measurements_inputs,
+        get_tactile_poses_from_values,
+        init_tactile_model_from_file,
+        update_tactile_pushing_inputs,
+        visualize_tactile_push2d,
+    )
+except ModuleNotFoundError:
+    print(
+        "Unable to import Tactile Pose Estimation utilities. "
+        "Please make sure you have matplotlib and omegaconf installed."
+    )


### PR DESCRIPTION
## Motivation and Context
Since core functionality doesn't depend on `matplotlib` and `omegaconf`, I think it's better to keep these installations optional. However, looks like the missing dependencies are breaking the test code in CI, so I added try/catch around import error with a warning message.
