### PR TITLE
Made AutoDiffCostFunction._tmp_optim_vars copies of original

### DIFF
--- a/theseus/core/cost_function.py
+++ b/theseus/core/cost_function.py
@@ -135,7 +135,7 @@ class AutoDiffCostFunction(CostFunction):
 
         # The following are auxiliary Variable objects to hold tensor data
         # during jacobian computation without modifying the original Variable objects
-        self._tmp_optim_vars = tuple(Variable(data=v.data) for v in optim_vars)
+        self._tmp_optim_vars = tuple(v.copy() for v in optim_vars)
 
     def _compute_error(
         self,


### PR DESCRIPTION
This preserves optimization variables types and can solve errors like [this](https://github.com/facebookresearch/theseus/pull/84#discussion_r847801204). 

Besides running unit tests, I also ran the `backward_modes.py` script and the first tutorial. Seems to be working w/o issues after this change. 

cc @exhaustin 
