### PR TITLE
Updated SDF object in collision cost functions whenever an aux var is updated

### DIFF
--- a/theseus/embodied/collision/collision.py
+++ b/theseus/embodied/collision/collision.py
@@ -71,3 +71,8 @@ class Collision2D(CostFunction):
 
     def dim(self) -> int:
         return 1
+
+    # This is needed so that the SDF container also updates with the new aux var
+    def set_aux_var_at(self, index: int, variable: Variable):
+        super().set_aux_var_at(index, variable)
+        self.sdf.update_data(self.sdf_origin, self.sdf_data, self.sdf_cell_size)

--- a/theseus/embodied/collision/eff_obj_contact.py
+++ b/theseus/embodied/collision/eff_obj_contact.py
@@ -114,3 +114,8 @@ class EffectorObjectContactPlanar(CostFunction):
 
     def dim(self) -> int:
         return 1
+
+    # This is needed so that the SDF container also updates with the new aux var
+    def set_aux_var_at(self, index: int, variable: Variable):
+        super().set_aux_var_at(index, variable)
+        self.sdf.update_data(self.sdf_origin, self.sdf_data, self.sdf_cell_size)

--- a/theseus/utils/utils.py
+++ b/theseus/utils/utils.py
@@ -49,11 +49,16 @@ def build_mlp(
 #      matrix -> batch_size x num_rows x num_cols
 #      rows/cols -> batch_size x num_points
 #
+# If the matrix's batch size is 1, broadcasting is supported by expanding the matrix
+# so that it has the batch size of rows and cols.
+#
 # Returns:
 #      data -> batch_size x num_points
 # where
 #      data[i, j] = matrix[i, rows[i, j], cols[i, j]]
 def gather_from_rows_cols(matrix: torch.Tensor, rows: torch.Tensor, cols: torch.Tensor):
+    if matrix.shape[0] == 1:
+        matrix = matrix.expand(rows.shape[0], -1, -1)
     assert matrix.ndim == 3 and rows.ndim == 2 and rows.ndim == 2
     assert matrix.shape[0] == rows.shape[0] and matrix.shape[0] == cols.shape[0]
     assert rows.shape[1] == cols.shape[1]


### PR DESCRIPTION
… updated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Calling `Objective.copy()` when there are `Collision2D` or `EffectorObjectContactPlanar` cost functions resulted in incorrect behavior, because the `sdf_data` variable container created was not being linked to the underlying `PlanarSDF` objects.  

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
I ran the code in #161 and seems to be working (where this bug was first detected).