### PR TITLE
Added a check in TheseusFunction that enforces copy() also copies the variables

### DIFF
--- a/theseus/core/tests/test_theseus_function.py
+++ b/theseus/core/tests/test_theseus_function.py
@@ -6,15 +6,15 @@ import numpy as np
 import pytest  # noqa: F401
 import torch
 
-import theseus.core
+import theseus as th
 
 from .common import MockCostFunction, MockCostWeight
 
 
 def test_theseus_function_init():
     all_ids = []
-    variables = [theseus.core.Variable(torch.ones(1, 1), name="var_1")]
-    aux_vars = [theseus.core.Variable(torch.ones(1, 1), name="aux_1")]
+    variables = [th.Variable(torch.ones(1, 1), name="var_1")]
+    aux_vars = [th.Variable(torch.ones(1, 1), name="aux_1")]
     for i in range(100):
         cost_weight = MockCostWeight(torch.ones(1, 1), name=f"cost_weight_{i}")
         if np.random.random() < 0.5:
@@ -31,8 +31,8 @@ def test_theseus_function_init():
 
 
 def test_no_copy_vars_check():
-    variables = [theseus.core.Variable(torch.ones(1, 1), name="var_1")]
-    aux_vars = [theseus.core.Variable(torch.ones(1, 1), name="aux_1")]
+    variables = [th.Variable(torch.ones(1, 1), name="var_1")]
+    aux_vars = [th.Variable(torch.ones(1, 1), name="aux_1")]
     cost_weight = MockCostWeight(torch.ones(1, 1), name="cost_weight")
     cost_function = MockCostFunction(
         variables, aux_vars, cost_weight, no_copy_vars=True

--- a/theseus/core/tests/test_theseus_function.py
+++ b/theseus/core/tests/test_theseus_function.py
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 import numpy as np
 import pytest  # noqa: F401
 import torch
@@ -29,3 +28,14 @@ def test_theseus_function_init():
             assert name == cost_function.name
 
     assert len(set(all_ids)) == len(all_ids)
+
+
+def test_no_copy_vars_check():
+    variables = [theseus.core.Variable(torch.ones(1, 1), name="var_1")]
+    aux_vars = [theseus.core.Variable(torch.ones(1, 1), name="aux_1")]
+    cost_weight = MockCostWeight(torch.ones(1, 1), name="cost_weight")
+    cost_function = MockCostFunction(
+        variables, aux_vars, cost_weight, no_copy_vars=True
+    )
+    with pytest.raises(RuntimeError):
+        cost_function.copy()

--- a/theseus/core/theseus_function.py
+++ b/theseus/core/theseus_function.py
@@ -91,8 +91,10 @@ class TheseusFunction(abc.ABC):
 
         if self._has_duplicate_vars(new_fn):
             raise RuntimeError(
-                "TheseusFunction.copy() resulted in one of the original variables "
-                "being reused. copy() requires all variables to be copied as well."
+                f"{self.__class__.__name__}.copy() resulted in one of the original "
+                "variables being reused. copy() requires all variables to be copied "
+                "to new variables, so please re-implement _copy_impl() to satisfy this "
+                "property."
             )
 
         return new_fn

--- a/theseus/core/theseus_function.py
+++ b/theseus/core/theseus_function.py
@@ -5,7 +5,7 @@
 
 import abc
 from itertools import count
-from typing import Generator, List, Optional, Sequence
+from typing import Generator, Iterable, List, Optional, Sequence
 
 from theseus.geometry import Manifold
 
@@ -69,6 +69,14 @@ class TheseusFunction(abc.ABC):
     def _copy_impl(self, new_name: Optional[str] = None) -> "TheseusFunction":
         pass
 
+    def _has_duplicate_vars(self, another: "TheseusFunction") -> bool:
+        def _check(base: Iterable[Variable], vectorized: Iterable[Variable]) -> bool:
+            return len(set(base) & set(vectorized)) > 0
+
+        return _check(self.optim_vars, another.optim_vars) | _check(
+            self.aux_vars, another.aux_vars
+        )
+
     def copy(
         self, new_name: Optional[str] = None, keep_variable_names: bool = False
     ) -> "TheseusFunction":
@@ -80,6 +88,13 @@ class TheseusFunction(abc.ABC):
                 new_var.name = old_var.name
             for old_aux, new_aux in zip(self.aux_vars, new_fn.aux_vars):
                 new_aux.name = old_aux.name
+
+        if self._has_duplicate_vars(new_fn):
+            raise RuntimeError(
+                "TheseusFunction.copy() resulted in one of the original variables "
+                "being reused. copy() requires all variables to be copied as well."
+            )
+
         return new_fn
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
We are using copy to create new variables in the cost function vectorization code, and this would help avoid some unwanted bugs if an user creates a new cost function that re-uses some of the old variables rather than copying. 