### PR TITLE
Probabilistically correct SO(3) sampling

### DIFF
--- a/theseus/geometry/so3.py
+++ b/theseus/geometry/so3.py
@@ -44,21 +44,34 @@ class SO3(LieGroup):
         device: Optional[torch.device] = None,
         requires_grad: bool = False,
     ) -> "SO3":
+        # Reference:
+        # https://web.archive.org/web/20211105205926/http://planning.cs.uiuc.edu/node198.html
         if len(size) != 1:
             raise ValueError("The size should be 1D.")
-        return SO3.exp_map(
-            2
-            * theseus.constants.PI
-            * torch.rand(
-                size[0],
-                3,
-                generator=generator,
-                dtype=dtype,
-                device=device,
-                requires_grad=requires_grad,
-            )
-            - theseus.constants.PI
+        u = torch.rand(
+            3,
+            size[0],
+            generator=generator,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
         )
+        u1 = u[0]
+        u2, u3 = u[1:3] * 2 * torch.pi
+
+        a = torch.sqrt(1.0 - u1)
+        b = torch.sqrt(u1)
+        quaternion = torch.stack(
+            [
+                a * torch.sin(u2),
+                a * torch.cos(u2),
+                b * torch.sin(u3),
+                b * torch.cos(u3),
+            ],
+            dim=1,
+        )
+        assert quaternion.shape == (size[0], 4)
+        return SO3(quaternion=quaternion)
 
     @staticmethod
     def randn(


### PR DESCRIPTION
## Motivation and Context

The current uniform sampling procedure for SO(3) works by:
1. Uniformly sampling in log/tangent space.
2. Applying the exponential map.

This would produce a uniform output if the exponential operation were linear, but it's unfortunately not.

As intuition for why there might be something funky afoot:
- If we consider a subset of the domain of `exp_map(omega)` where `l2_norm(omega) = 2 * pi`, all inputs maps to a singleton.
- If we consider a subset of the domain of `exp_map(omega)` where `l2_norm(omega) = pi`, the function is bijective, and produces a unique rotation for each unique tangent vector.

## How Has This Been Tested

Unit tests still pass!

The implementation is also battle-tested:
- This is a near-identical PR as this 2019 one to Sophus: https://github.com/strasdat/Sophus/pull/233
- It's a port from the [jaxlie](https://github.com/brentyi/jaxlie/blob/0d3c2086a2707df0fadcaca61c0df48ad5853339/jaxlie/_so3.py#L404-L427) implementation.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
