### PR TITLE
Rename BackwardMode.FULL --> UNROLL and simplify backward mode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ outer_optimizer = torch.optim.RMSprop([phi], lr=0.001)
 for epoch in range(10):
     solution, info = layer.forward(
         input_tensors={"x": phi.clone(), "v": torch.ones(1, 1)},
-        optimizer_kwargs={"backward_mode": th.BackwardMode.IMPLICIT})
+        optimizer_kwargs={"backward_mode": "implicit"})
     outer_loss = torch.nn.functional.mse_loss(solution["v"], v_true)
     outer_loss.backward()
     outer_optimizer.step()

--- a/examples/backward_modes.py
+++ b/examples/backward_modes.py
@@ -82,7 +82,7 @@ updated_inputs, info = theseus_optim.forward(
     optimizer_kwargs={
         "track_best_solution": True,
         "verbose": False,
-        "backward_mode": "full",
+        "backward_mode": "unroll",
     },
 )
 
@@ -175,7 +175,7 @@ for trial in range(n_trials + 1):
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": "full",
+            "backward_mode": "unroll",
         },
     )
     times["fwd"].append(time.time() - start)

--- a/examples/backward_modes.py
+++ b/examples/backward_modes.py
@@ -82,7 +82,7 @@ updated_inputs, info = theseus_optim.forward(
     optimizer_kwargs={
         "track_best_solution": True,
         "verbose": False,
-        "backward_mode": th.BackwardMode.FULL,
+        "backward_mode": "full",
     },
 )
 
@@ -103,7 +103,7 @@ updated_inputs, info = theseus_optim.forward(
     optimizer_kwargs={
         "track_best_solution": True,
         "verbose": False,
-        "backward_mode": th.BackwardMode.IMPLICIT,
+        "backward_mode": "implicit",
     },
 )
 
@@ -117,7 +117,7 @@ updated_inputs, info = theseus_optim.forward(
     optimizer_kwargs={
         "track_best_solution": True,
         "verbose": False,
-        "backward_mode": th.BackwardMode.TRUNCATED,
+        "backward_mode": "truncated",
         "backward_num_iterations": 5,
     },
 )
@@ -134,7 +134,7 @@ updated_inputs, info = theseus_optim.forward(
     optimizer_kwargs={
         "track_best_solution": True,
         "verbose": False,
-        "backward_mode": th.BackwardMode.DLM,
+        "backward_mode": "dlm",
         "dlm_epsilon": 1e-3,
     },
 )
@@ -175,7 +175,7 @@ for trial in range(n_trials + 1):
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.FULL,
+            "backward_mode": "full",
         },
     )
     times["fwd"].append(time.time() - start)
@@ -191,7 +191,7 @@ for trial in range(n_trials + 1):
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.IMPLICIT,
+            "backward_mode": "implicit",
         },
     )
     start = time.time()
@@ -205,7 +205,7 @@ for trial in range(n_trials + 1):
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.TRUNCATED,
+            "backward_mode": "truncated",
             "backward_num_iterations": 5,
         },
     )
@@ -220,7 +220,7 @@ for trial in range(n_trials + 1):
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.DLM,
+            "backward_mode": "dlm",
             "dlm_epsilon": 1e-3,
         },
     )

--- a/examples/bundle_adjustment.py
+++ b/examples/bundle_adjustment.py
@@ -17,13 +17,6 @@ import torch
 import theseus as th
 import theseus.utils.examples as theg
 
-BACKWARD_MODE = {
-    "implicit": th.BackwardMode.IMPLICIT,
-    "full": th.BackwardMode.FULL,
-    "truncated": th.BackwardMode.TRUNCATED,
-}
-
-
 # Logger
 log = logging.getLogger(__name__)
 
@@ -211,7 +204,7 @@ def run(cfg: omegaconf.OmegaConf, results_path: pathlib.Path):
             optimizer_kwargs={
                 "verbose": cfg.inner_optim.verbose,
                 "track_err_history": cfg.inner_optim.track_err_history,
-                "backward_mode": BACKWARD_MODE[cfg.inner_optim.backward_mode],
+                "backward_mode": cfg.inner_optim.backward_mode,
                 "__keep_final_step_size__": cfg.inner_optim.keep_step_size,
             },
         )

--- a/examples/homography_estimation.py
+++ b/examples/homography_estimation.py
@@ -32,11 +32,6 @@ FONT = cv2.FONT_HERSHEY_DUPLEX
 FONT_SZ = 0.5
 FONT_PT = (5, 15)
 
-BACKWARD_MODE = {
-    "implicit": th.BackwardMode.IMPLICIT,
-    "full": th.BackwardMode.FULL,
-    "truncated": th.BackwardMode.TRUNCATED,
-}
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -406,7 +401,7 @@ def run(
                     "verbose": verbose,
                     "track_err_history": True,
                     "track_state_history": True,
-                    "backward_mode": BACKWARD_MODE["implicit"],
+                    "backward_mode": "implicit",
                 },
             )
             end_event.record()

--- a/examples/pose_graph/pose_graph_synthetic.py
+++ b/examples/pose_graph/pose_graph_synthetic.py
@@ -24,12 +24,6 @@ import theseus.utils.examples as theg
 from theseus.optimizer.linear import LinearSolver
 from theseus.optimizer.linearization import Linearization
 
-BACKWARD_MODE = {
-    "implicit": th.BackwardMode.IMPLICIT,
-    "full": th.BackwardMode.FULL,
-    "truncated": th.BackwardMode.TRUNCATED,
-}
-
 LINEARIZATION_MODE: Dict[str, Type[Linearization]] = {
     "sparse": th.SparseLinearization,
     "dense": th.DenseLinearization,
@@ -97,12 +91,6 @@ def run(
     device = torch.device("cuda")
     dtype = torch.float64
     pr = cProfile.Profile()
-
-    BACKWARD_MODE = {
-        "implicit": th.BackwardMode.IMPLICIT,
-        "full": th.BackwardMode.FULL,
-        "truncated": th.BackwardMode.TRUNCATED,
-    }
 
     LINEARIZATION_MODE: Dict[str, Type[Linearization]] = {
         "sparse": th.SparseLinearization,
@@ -232,7 +220,7 @@ def run(
             optimizer_kwargs={
                 "verbose": cfg.inner_optim.verbose,
                 "track_err_history": cfg.inner_optim.track_err_history,
-                "backward_mode": BACKWARD_MODE[cfg.inner_optim.backward_mode],
+                "backward_mode": cfg.inner_optim.backward_mode,
                 "__keep_final_step_size__": cfg.inner_optim.keep_step_size,
             },
         )

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -49,7 +49,7 @@ outer_optimizer = torch.optim.RMSprop([phi], lr=0.001)
 for epoch in range(20):
     solution, info = layer.forward(
         input_tensors={"x": phi.clone(), "v": torch.ones(1, 1)},
-        optimizer_kwargs={"backward_mode": th.BackwardMode.IMPLICIT},
+        optimizer_kwargs={"backward_mode": "implicit"},
     )
     outer_loss = torch.nn.functional.mse_loss(solution["v"], v_true)
     outer_loss.backward()

--- a/theseus/optimizer/nonlinear/tests/test_backwards.py
+++ b/theseus/optimizer/nonlinear/tests/test_backwards.py
@@ -85,7 +85,7 @@ def test_backwards():
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": "full",
+            "backward_mode": "unroll",
         },
     )
     da_dx_full = torch.autograd.grad(updated_inputs["a"], data_x, retain_graph=True)[

--- a/theseus/optimizer/nonlinear/tests/test_backwards.py
+++ b/theseus/optimizer/nonlinear/tests/test_backwards.py
@@ -85,7 +85,7 @@ def test_backwards():
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.FULL,
+            "backward_mode": "full",
         },
     )
     da_dx_full = torch.autograd.grad(updated_inputs["a"], data_x, retain_graph=True)[
@@ -111,7 +111,7 @@ def test_backwards():
         optimizer_kwargs={
             "track_best_solution": True,
             "verbose": False,
-            "backward_mode": th.BackwardMode.TRUNCATED,
+            "backward_mode": "TRUNCATED",
             "backward_num_iterations": 5,
         },
     )

--- a/theseus/tests/test_dlm_perturbation.py
+++ b/theseus/tests/test_dlm_perturbation.py
@@ -97,7 +97,7 @@ def test_backward_pass_se3_runs():
             out, _ = layer.forward(
                 {"target": target_data},
                 optimizer_kwargs={
-                    "backward_mode": th.BackwardMode.DLM,
+                    "backward_mode": "dlm",
                     "verbose": False,
                 },
             )

--- a/theseus/theseus_layer.py
+++ b/theseus/theseus_layer.py
@@ -51,7 +51,10 @@ class TheseusLayer(nn.Module):
                 "currently not supported."
             )
         optimizer_kwargs = optimizer_kwargs or {}
-        backward_mode = optimizer_kwargs.get("backward_mode", None)
+        # Defaults to "full" to avoid error, we only care to see if it's not dlm.
+        backward_mode = BackwardMode.resolve(
+            optimizer_kwargs.get("backward_mode", "full")
+        )
         if backward_mode == BackwardMode.DLM:
             dlm_epsilon = optimizer_kwargs.get(
                 TheseusLayerDLMForward._DLM_EPSILON_STR, 1e-2

--- a/theseus/theseus_layer.py
+++ b/theseus/theseus_layer.py
@@ -51,9 +51,9 @@ class TheseusLayer(nn.Module):
                 "currently not supported."
             )
         optimizer_kwargs = optimizer_kwargs or {}
-        # Defaults to "full" to avoid error, we only care to see if it's not dlm.
+        # Defaults to "unroll" to avoid error, we only care to see if it's not dlm.
         backward_mode = BackwardMode.resolve(
-            optimizer_kwargs.get("backward_mode", "full")
+            optimizer_kwargs.get("backward_mode", "unroll")
         )
         if backward_mode == BackwardMode.DLM:
             dlm_epsilon = optimizer_kwargs.get(

--- a/theseus/utils/examples/tactile_pose_estimation/trainer.py
+++ b/theseus/utils/examples/tactile_pose_estimation/trainer.py
@@ -192,7 +192,7 @@ class TactilePushingTrainer:
             logger.info("Forcing IMPLICIT backward mode.")
             return th.BackwardMode.IMPLICIT
         else:
-            return getattr(th.BackwardMode, self.cfg.inner_optim.backward_mode)
+            return self.cfg.inner_optim.backward_mode
 
     def compute_loss(
         self, epoch: int, update: bool = True


### PR DESCRIPTION
We can now pass strings to specify backward modes, instead of having to pass the specific enum type. 