### PR TITLE
Adaptive damping for Levenberg-Marquardt

### DIFF
--- a/theseus/extlib/baspacho_solver.cpp
+++ b/theseus/extlib/baspacho_solver.cpp
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "baspacho_solver.h"
+#include "utils.h"
 #include <iostream>
 
 using namespace BaSpaCho;
@@ -40,9 +41,9 @@ void NumericDecomposition::add_M(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TH_BASPACHO_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CPU(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
     int64_t valBatchStride = val.size(1);
 
     const double* pVal = val.data_ptr<double>();
@@ -102,9 +103,9 @@ void NumericDecomposition::add_MtM(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TH_BASPACHO_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(ptrs, 1, ptrs.size(0), torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CPU(ptrs, 1, ptrs.size(0), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
     int64_t valBatchStride = val.size(1);
 
     const double* pVal = val.data_ptr<double>();
@@ -159,14 +160,14 @@ void NumericDecomposition::add_MtM(const torch::Tensor& val,
 void NumericDecomposition::damp(const torch::Tensor& alpha, const torch::Tensor& beta) {
 #ifdef THESEUS_HAVE_CUDA
     if (dec->isCuda) {
-        TH_BASPACHO_TENSOR_CHECK_CUDA(alpha, 1, data.size(0), torch::kFloat64);
-        TH_BASPACHO_TENSOR_CHECK_CUDA(beta, 1, data.size(0), torch::kFloat64);
+        THESEUS_TENSOR_CHECK_CUDA(alpha, 1, data.size(0), torch::kFloat64);
+        THESEUS_TENSOR_CHECK_CUDA(beta, 1, data.size(0), torch::kFloat64);
         damp_cuda(alpha.data_ptr<double>(), beta.data_ptr<double>());
         return;
     }
 #endif
-    TH_BASPACHO_TENSOR_CHECK_CPU(alpha, 1, data.size(0), torch::kFloat64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(beta, 1, data.size(0), torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CPU(alpha, 1, data.size(0), torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CPU(beta, 1, data.size(0), torch::kFloat64);
 
     int64_t batchSize = data.size(0);
     int64_t factorSize = data.size(1);
@@ -212,7 +213,7 @@ void NumericDecomposition::solve(torch::Tensor& x) {
 
     int64_t batchSize = data.size(0);
     int64_t order = dec->solver->order();
-    TH_BASPACHO_TENSOR_CHECK_CPU(x, 2, batchSize, x.dtype());
+    THESEUS_TENSOR_CHECK_CPU(x, 2, batchSize, x.dtype());
     TORCH_CHECK(x.size(1) == order);
 
     using OuterStride = Eigen::OuterStride<>;
@@ -258,9 +259,9 @@ void NumericDecomposition::solve(torch::Tensor& x) {
 SymbolicDecomposition::SymbolicDecomposition(
     const torch::Tensor& paramSize, const torch::Tensor& sparseStructPtrs,
     const torch::Tensor& sparseStructInds, const std::string& device) {
-    TH_BASPACHO_TENSOR_CHECK_CPU(paramSize, 1, sparseStructPtrs.size(0) - 1, torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(sparseStructPtrs, 1, sparseStructPtrs.size(0), torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CPU(sparseStructInds, 1, sparseStructInds.size(0), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(paramSize, 1, sparseStructPtrs.size(0) - 1, torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(sparseStructPtrs, 1, sparseStructPtrs.size(0), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CPU(sparseStructInds, 1, sparseStructInds.size(0), torch::kInt64);
 #ifdef THESEUS_HAVE_CUDA
     TORCH_CHECK(device == "cpu" || device == "cuda");
 #else

--- a/theseus/extlib/baspacho_solver.cpp
+++ b/theseus/extlib/baspacho_solver.cpp
@@ -40,19 +40,9 @@ void NumericDecomposition::add_M(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TORCH_CHECK(val.device().is_cpu());
-    TORCH_CHECK(ptrs.device().is_cpu());
-    TORCH_CHECK(inds.device().is_cpu());
-    TORCH_CHECK(val.dtype() == torch::kFloat64);
-    TORCH_CHECK(ptrs.dtype() == torch::kInt64);
-    TORCH_CHECK(inds.dtype() == torch::kInt64);
-    TORCH_CHECK(val.dim() == 2);
-    TORCH_CHECK(ptrs.dim() == 1);
-    TORCH_CHECK(inds.dim() == 1);
-    TORCH_CHECK(val.size(0) == batchSize);
-    TORCH_CHECK(val.size(1) == inds.size(0));
-    TORCH_CHECK(ptrs.size(0) - 1 == dec->solver->order());
-
+    TH_BASPACHO_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
     int64_t valBatchStride = val.size(1);
 
     const double* pVal = val.data_ptr<double>();
@@ -112,18 +102,9 @@ void NumericDecomposition::add_MtM(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TORCH_CHECK(val.device().is_cpu());
-    TORCH_CHECK(ptrs.device().is_cpu());
-    TORCH_CHECK(inds.device().is_cpu());
-    TORCH_CHECK(val.dtype() == torch::kFloat64);
-    TORCH_CHECK(ptrs.dtype() == torch::kInt64);
-    TORCH_CHECK(inds.dtype() == torch::kInt64);
-    TORCH_CHECK(val.dim() == 2);
-    TORCH_CHECK(ptrs.dim() == 1);
-    TORCH_CHECK(inds.dim() == 1);
-    TORCH_CHECK(val.size(0) == batchSize);
-    TORCH_CHECK(val.size(1) == inds.size(0));
-
+    TH_BASPACHO_TENSOR_CHECK_CPU(val, 2, batchSize, torch::kFloat64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(ptrs, 1, ptrs.size(0), torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(inds, 1, val.size(1), torch::kInt64);
     int64_t valBatchStride = val.size(1);
 
     const double* pVal = val.data_ptr<double>();
@@ -176,22 +157,16 @@ void NumericDecomposition::add_MtM(const torch::Tensor& val,
 }
 
 void NumericDecomposition::damp(const torch::Tensor& alpha, const torch::Tensor& beta) {
-    TORCH_CHECK(alpha.dtype() == torch::kFloat64);
-    TORCH_CHECK(alpha.dim() == 1);
-    TORCH_CHECK(alpha.size(0) == data.size(0));
-    TORCH_CHECK(beta.dtype() == torch::kFloat64);
-    TORCH_CHECK(beta.dim() == 1);
-    TORCH_CHECK(beta.size(0) == data.size(0));
-
 #ifdef THESEUS_HAVE_CUDA
     if (dec->isCuda) {
-        TORCH_CHECK(alpha.device().is_cuda());
-        TORCH_CHECK(beta.device().is_cuda());
+        TH_BASPACHO_TENSOR_CHECK_CUDA(alpha, 1, data.size(0), torch::kFloat64);
+        TH_BASPACHO_TENSOR_CHECK_CUDA(beta, 1, data.size(0), torch::kFloat64);
         damp_cuda(alpha.data_ptr<double>(), beta.data_ptr<double>());
         return;
     }
 #endif
-    TORCH_CHECK(alpha.device().is_cpu());
+    TH_BASPACHO_TENSOR_CHECK_CPU(alpha, 1, data.size(0), torch::kFloat64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(beta, 1, data.size(0), torch::kFloat64);
 
     int64_t batchSize = data.size(0);
     int64_t factorSize = data.size(1);
@@ -237,9 +212,7 @@ void NumericDecomposition::solve(torch::Tensor& x) {
 
     int64_t batchSize = data.size(0);
     int64_t order = dec->solver->order();
-    TORCH_CHECK(x.device().is_cpu());
-    TORCH_CHECK(x.dim() == 2);
-    TORCH_CHECK(x.size(0) == batchSize);
+    TH_BASPACHO_TENSOR_CHECK_CPU(x, 2, batchSize, x.dtype());
     TORCH_CHECK(x.size(1) == order);
 
     using OuterStride = Eigen::OuterStride<>;
@@ -285,16 +258,9 @@ void NumericDecomposition::solve(torch::Tensor& x) {
 SymbolicDecomposition::SymbolicDecomposition(
     const torch::Tensor& paramSize, const torch::Tensor& sparseStructPtrs,
     const torch::Tensor& sparseStructInds, const std::string& device) {
-    TORCH_CHECK(paramSize.device().is_cpu());
-    TORCH_CHECK(sparseStructPtrs.device().is_cpu());
-    TORCH_CHECK(sparseStructInds.device().is_cpu());
-    TORCH_CHECK(paramSize.dtype() == torch::kInt64);
-    TORCH_CHECK(sparseStructPtrs.dtype() == torch::kInt64);
-    TORCH_CHECK(sparseStructInds.dtype() == torch::kInt64);
-    TORCH_CHECK(paramSize.dim() == 1);
-    TORCH_CHECK(sparseStructPtrs.dim() == 1);
-    TORCH_CHECK(sparseStructInds.dim() == 1);
-    TORCH_CHECK(paramSize.size(0) + 1 == sparseStructPtrs.size(0));
+    TH_BASPACHO_TENSOR_CHECK_CPU(paramSize, 1, sparseStructPtrs.size(0) - 1, torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(sparseStructPtrs, 1, sparseStructPtrs.size(0), torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CPU(sparseStructInds, 1, sparseStructInds.size(0), torch::kInt64);
 #ifdef THESEUS_HAVE_CUDA
     TORCH_CHECK(device == "cpu" || device == "cuda");
 #else

--- a/theseus/extlib/baspacho_solver.h
+++ b/theseus/extlib/baspacho_solver.h
@@ -39,7 +39,7 @@ class NumericDecomposition {
                  const torch::Tensor& inds);
 
     // apply damping, ie on factor diag x -> x*(1+alpha) + beta (auto Cpu/Cuda)
-    void damp(double alpha, double beta);
+    void damp(const torch::Tensor& alpha, double beta);
 
     // in-place solves on vector data, batch size must match (auto Cpu/Cuda)
     void factor();
@@ -57,7 +57,7 @@ class NumericDecomposition {
                       const torch::Tensor& inds);
 
     // apply damping, ie on factor diag x -> x*(1+alpha) + beta (Cuda)
-    void damp_cuda(double alpha, double beta);
+    void damp_cuda(double* alpha, double beta);
 
     // computes Cholesky factorization, in-place on the factor (Cuda)
     void factor_cuda();

--- a/theseus/extlib/baspacho_solver.h
+++ b/theseus/extlib/baspacho_solver.h
@@ -9,6 +9,28 @@
 
 #include "baspacho/baspacho/Solver.h"
 
+
+// Various checks for tensor dimensions, dtype and devices
+#define TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt)             \
+  do {                                                          \
+    TORCH_CHECK(tensor.dim() == d);                             \
+    TORCH_CHECK(tensor.size(0) == d1);                          \
+    TORCH_CHECK(tensor.dtype() == dt);                          \
+  } while (0)
+
+#define TH_BASPACHO_TENSOR_CHECK_CPU(tensor, d, d1, dt)         \
+  do {                                                          \
+    TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt);                \
+    TORCH_CHECK(tensor.device().is_cpu());                      \
+  } while (0)
+
+#define TH_BASPACHO_TENSOR_CHECK_CUDA(tensor, d, d1, dt)        \
+  do {                                                          \
+    TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt);                \
+    TORCH_CHECK(tensor.device().is_cuda());                     \
+  } while (0)
+
+
 // Data stored in a symbolic decomposition, result from analyzing sparse pattern.
 //
 // Both Python's symbolic decomposition and numeric decomposition will hold a

--- a/theseus/extlib/baspacho_solver.h
+++ b/theseus/extlib/baspacho_solver.h
@@ -39,7 +39,7 @@ class NumericDecomposition {
                  const torch::Tensor& inds);
 
     // apply damping, ie on factor diag x -> x*(1+alpha) + beta (auto Cpu/Cuda)
-    void damp(const torch::Tensor& alpha, double beta);
+    void damp(const torch::Tensor& alpha, const torch::Tensor& beta);
 
     // in-place solves on vector data, batch size must match (auto Cpu/Cuda)
     void factor();
@@ -57,7 +57,7 @@ class NumericDecomposition {
                       const torch::Tensor& inds);
 
     // apply damping, ie on factor diag x -> x*(1+alpha) + beta (Cuda)
-    void damp_cuda(double* alpha, double beta);
+    void damp_cuda(double* alpha, double* beta);
 
     // computes Cholesky factorization, in-place on the factor (Cuda)
     void factor_cuda();

--- a/theseus/extlib/baspacho_solver.h
+++ b/theseus/extlib/baspacho_solver.h
@@ -10,27 +10,6 @@
 #include "baspacho/baspacho/Solver.h"
 
 
-// Various checks for tensor dimensions, dtype and devices
-#define TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt)             \
-  do {                                                          \
-    TORCH_CHECK(tensor.dim() == d);                             \
-    TORCH_CHECK(tensor.size(0) == d1);                          \
-    TORCH_CHECK(tensor.dtype() == dt);                          \
-  } while (0)
-
-#define TH_BASPACHO_TENSOR_CHECK_CPU(tensor, d, d1, dt)         \
-  do {                                                          \
-    TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt);                \
-    TORCH_CHECK(tensor.device().is_cpu());                      \
-  } while (0)
-
-#define TH_BASPACHO_TENSOR_CHECK_CUDA(tensor, d, d1, dt)        \
-  do {                                                          \
-    TH_BASPACHO_TENSOR_CHECK(tensor, d, d1, dt);                \
-    TORCH_CHECK(tensor.device().is_cuda());                     \
-  } while (0)
-
-
 // Data stored in a symbolic decomposition, result from analyzing sparse pattern.
 //
 // Both Python's symbolic decomposition and numeric decomposition will hold a

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -185,7 +185,7 @@ void NumericDecomposition::add_MtM_cuda(const torch::Tensor& val,
 
 __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
                      double* pFactor, int64_t factorSize,
-                     double alpha, double beta,
+                     double* alpha, double beta,
                      int64_t maxI, int batchSize) {
     int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
     int batchIndex = blockIdx.y * blockDim.y + threadIdx.y;
@@ -195,11 +195,11 @@ __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
 
     double* pFactorItem = pFactor + factorSize * batchIndex;
     auto block = accessor.diagBlock(pFactorItem, i);
-    block.diagonal() *= (1.0 + alpha);
+    block.diagonal() *= (1.0 + alpha[batchIndex]);
     block.diagonal().array() += beta;
 }
 
-void NumericDecomposition::damp_cuda(double alpha, double beta) {
+void NumericDecomposition::damp_cuda(double* alpha, double beta) {
     int64_t batchSize = data.size(0);
     int64_t factorSize = data.size(1);
     double* pFactor = data.data_ptr<double>();

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -196,7 +196,7 @@ __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
     double* pFactorItem = pFactor + factorSize * batchIndex;
     auto block = accessor.diagBlock(pFactorItem, i);
     block.diagonal() *= (1.0 + alpha[batchIndex]);
-    block.diagonal() += beta[batchIndex];
+    block.diagonal().array() += beta[batchIndex];
 }
 
 void NumericDecomposition::damp_cuda(double* alpha, double* beta) {

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -196,7 +196,7 @@ __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
     double* pFactorItem = pFactor + factorSize * batchIndex;
     auto block = accessor.diagBlock(pFactorItem, i);
     block.diagonal() *= (1.0 + alpha[batchIndex]);
-    block.diagonal().array() += beta[batchIndex];
+    block.diagonal() += beta[batchIndex];
 }
 
 void NumericDecomposition::damp_cuda(double* alpha, double* beta) {

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -8,6 +8,7 @@
 
 #include "baspacho_solver.h"
 #include "baspacho/baspacho/CudaDefs.h"
+#include "utils.h"
 
 void NumericDecomposition::init_factor_data_cuda(int64_t batchSize) {
     auto xOptions = torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA);
@@ -62,9 +63,9 @@ void NumericDecomposition::add_M_cuda(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TH_BASPACHO_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
-    TH_BASPACHO_TENSOR_CHECK_CUDA(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CUDA(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
+    THESEUS_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
 
 
     int64_t valBatchStride = val.size(1);
@@ -138,9 +139,9 @@ void NumericDecomposition::add_MtM_cuda(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TH_BASPACHO_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
-    TH_BASPACHO_TENSOR_CHECK_CUDA(ptrs, 1, ptrs.size(0), torch::kInt64);
-    TH_BASPACHO_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
+    THESEUS_TENSOR_CHECK_CUDA(ptrs, 1, ptrs.size(0), torch::kInt64);
+    THESEUS_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
     
     int64_t valBatchStride = val.size(1);
 
@@ -251,7 +252,7 @@ __global__ void unscramble_kernel(BaSpaCho::PermutedCoalescedAccessor acc,
 void NumericDecomposition::solve_cuda(torch::Tensor& x) {
     int64_t batchSize = data.size(0);
     int64_t order = dec->solver->order();
-    TH_BASPACHO_TENSOR_CHECK_CUDA(x, 2, batchSize, x.dtype());
+    THESEUS_TENSOR_CHECK_CUDA(x, 2, batchSize, x.dtype());
     TORCH_CHECK(x.size(1) == order);
 
     using OuterStride = Eigen::OuterStride<>;

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -185,7 +185,7 @@ void NumericDecomposition::add_MtM_cuda(const torch::Tensor& val,
 
 __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
                      double* pFactor, int64_t factorSize,
-                     double* alpha, double beta,
+                     double* alpha, double* beta,
                      int64_t maxI, int batchSize) {
     int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
     int batchIndex = blockIdx.y * blockDim.y + threadIdx.y;
@@ -196,10 +196,10 @@ __global__ void damp_kernel(BaSpaCho::PermutedCoalescedAccessor accessor,
     double* pFactorItem = pFactor + factorSize * batchIndex;
     auto block = accessor.diagBlock(pFactorItem, i);
     block.diagonal() *= (1.0 + alpha[batchIndex]);
-    block.diagonal().array() += beta;
+    block.diagonal().array() += beta[batchIndex];
 }
 
-void NumericDecomposition::damp_cuda(double* alpha, double beta) {
+void NumericDecomposition::damp_cuda(double* alpha, double* beta) {
     int64_t batchSize = data.size(0);
     int64_t factorSize = data.size(1);
     double* pFactor = data.data_ptr<double>();

--- a/theseus/extlib/baspacho_solver_cuda.cu
+++ b/theseus/extlib/baspacho_solver_cuda.cu
@@ -62,18 +62,10 @@ void NumericDecomposition::add_M_cuda(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TORCH_CHECK(val.device().is_cuda());
-    TORCH_CHECK(ptrs.device().is_cuda());
-    TORCH_CHECK(inds.device().is_cuda());
-    TORCH_CHECK(val.dtype() == torch::kFloat64);
-    TORCH_CHECK(ptrs.dtype() == torch::kInt64);
-    TORCH_CHECK(inds.dtype() == torch::kInt64);
-    TORCH_CHECK(val.dim() == 2);
-    TORCH_CHECK(ptrs.dim() == 1);
-    TORCH_CHECK(inds.dim() == 1);
-    TORCH_CHECK(val.size(0) == batchSize);
-    TORCH_CHECK(val.size(1) == inds.size(0));
-    TORCH_CHECK(ptrs.size(0) - 1 == dec->solver->order());
+    TH_BASPACHO_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
+    TH_BASPACHO_TENSOR_CHECK_CUDA(ptrs, 1, dec->solver->order() + 1, torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
+
 
     int64_t valBatchStride = val.size(1);
 
@@ -146,18 +138,10 @@ void NumericDecomposition::add_MtM_cuda(const torch::Tensor& val,
     int64_t batchSize = data.size(0);
     int64_t factorBatchStride = data.size(1);
 
-    TORCH_CHECK(val.device().is_cuda());
-    TORCH_CHECK(ptrs.device().is_cuda());
-    TORCH_CHECK(inds.device().is_cuda());
-    TORCH_CHECK(val.dtype() == torch::kFloat64);
-    TORCH_CHECK(ptrs.dtype() == torch::kInt64);
-    TORCH_CHECK(inds.dtype() == torch::kInt64);
-    TORCH_CHECK(val.dim() == 2);
-    TORCH_CHECK(ptrs.dim() == 1);
-    TORCH_CHECK(inds.dim() == 1);
-    TORCH_CHECK(val.size(0) == batchSize);
-    TORCH_CHECK(val.size(1) == inds.size(0));
-
+    TH_BASPACHO_TENSOR_CHECK_CUDA(val, 2, batchSize, torch::kFloat64);
+    TH_BASPACHO_TENSOR_CHECK_CUDA(ptrs, 1, ptrs.size(0), torch::kInt64);
+    TH_BASPACHO_TENSOR_CHECK_CUDA(inds, 1, val.size(1), torch::kInt64);
+    
     int64_t valBatchStride = val.size(1);
 
     const double* pVal = val.data_ptr<double>();
@@ -267,9 +251,7 @@ __global__ void unscramble_kernel(BaSpaCho::PermutedCoalescedAccessor acc,
 void NumericDecomposition::solve_cuda(torch::Tensor& x) {
     int64_t batchSize = data.size(0);
     int64_t order = dec->solver->order();
-    TORCH_CHECK(x.device().is_cuda());
-    TORCH_CHECK(x.dim() == 2);
-    TORCH_CHECK(x.size(0) == batchSize);
+    TH_BASPACHO_TENSOR_CHECK_CUDA(x, 2, batchSize, x.dtype());
     TORCH_CHECK(x.size(1) == order);
 
     using OuterStride = Eigen::OuterStride<>;

--- a/theseus/extlib/mat_mult.cu
+++ b/theseus/extlib/mat_mult.cu
@@ -14,6 +14,8 @@
 #include <ATen/cuda/detail/DeviceThreadHandles.h>
 #include <ATen/cuda/CUDAContext.h>
 
+#include "utils.h"
+
 __device__ int bisect_index(const int* values, int len, int needle) {
 
 	int a = 0, b = len;
@@ -86,16 +88,10 @@ torch::Tensor mult_MtM(int batchSize,
 	int64_t M_numRows = M_rowPtr.size(0) - 1;
 	int64_t M_nnz = M_colInd.size(0);
 
-	TORCH_CHECK(M_rowPtr.device().is_cuda());
-	TORCH_CHECK(M_colInd.device().is_cuda());
-	TORCH_CHECK(Ms_val.device().is_cuda());
-	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt);
-	TORCH_CHECK(M_colInd.dtype() == torch::kInt);
-	TORCH_CHECK(Ms_val.dtype() == torch::kDouble); // TODO: add support for float
-	TORCH_CHECK(M_rowPtr.dim() == 1);
-	TORCH_CHECK(M_colInd.dim() == 1);
-	TORCH_CHECK(Ms_val.dim() == 2);
-	TORCH_CHECK(Ms_val.size(0) == batchSize);
+	THESEUS_TENSOR_CHECK_CUDA(M_rowPtr, 1, M_rowPtr.size(0), torch::kInt);
+	THESEUS_TENSOR_CHECK_CUDA(M_colInd, 1, M_colInd.size(0), torch::kInt);
+	// TODO: add support for float
+	THESEUS_TENSOR_CHECK_CUDA(Ms_val, 2, batchSize, torch::kDouble);
 	TORCH_CHECK(Ms_val.size(1) == M_nnz);
 
 	int64_t MtM_numRows = MtM_rowPtr.size(0) - 1;
@@ -177,20 +173,13 @@ torch::Tensor mat_vec(int batchSize,
 	int64_t M_nnz = M_colInd.size(0);
 
 	TORCH_CHECK(M_rowPtr.device().is_cuda());
-	TORCH_CHECK(M_colInd.device().is_cuda());
-	TORCH_CHECK(Ms_val.device().is_cuda());
-	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt || M_rowPtr.dtype() == torch::kInt64);
-	TORCH_CHECK(M_colInd.dtype() == M_rowPtr.dtype());
-	TORCH_CHECK(Ms_val.dtype() == torch::kDouble); // TODO: add support for float
 	TORCH_CHECK(M_rowPtr.dim() == 1);
-	TORCH_CHECK(M_colInd.dim() == 1);
-	TORCH_CHECK(Ms_val.dim() == 2);
-	TORCH_CHECK(Ms_val.size(0) == batchSize);
+	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt || M_rowPtr.dtype() == torch::kInt64);
+	THESEUS_TENSOR_CHECK_CUDA(M_colInd, 1, M_colInd.size(0), M_rowPtr.dtype());
+	// TODO: add support for float
+	THESEUS_TENSOR_CHECK_CUDA(Ms_val, 2, batchSize, torch::kDouble);
 	TORCH_CHECK(Ms_val.size(1) == M_nnz);
-	TORCH_CHECK(vec.device().is_cuda());
-	TORCH_CHECK(vec.dim() == 2);
-	TORCH_CHECK(vec.size(0) == batchSize);
-	TORCH_CHECK(vec.size(1) == M_numCols);
+	THESEUS_TENSOR_CHECK_CUDA(vec, 2, batchSize, vec.dtype());
 	
 	auto xOptions = torch::TensorOptions().dtype(torch::kDouble).device(Ms_val.device());
 	torch::Tensor retv = torch::empty({(long)batchSize, (long)M_numRows}, xOptions);
@@ -264,19 +253,13 @@ torch::Tensor tmat_vec(int batchSize,
 	int64_t M_nnz = M_colInd.size(0);
 
 	TORCH_CHECK(M_rowPtr.device().is_cuda());
-	TORCH_CHECK(M_colInd.device().is_cuda());
-	TORCH_CHECK(Ms_val.device().is_cuda());
 	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt || M_rowPtr.dtype() == torch::kInt64);
-	TORCH_CHECK(M_colInd.dtype() == M_rowPtr.dtype());
-	TORCH_CHECK(Ms_val.dtype() == torch::kDouble); // TODO: add support for float
 	TORCH_CHECK(M_rowPtr.dim() == 1);
-	TORCH_CHECK(M_colInd.dim() == 1);
-	TORCH_CHECK(Ms_val.dim() == 2);
-	TORCH_CHECK(Ms_val.size(0) == batchSize);
+	THESEUS_TENSOR_CHECK_CUDA(M_colInd, 1, M_colInd.size(0), M_rowPtr.dtype());
+	// TODO: add support for float
+	THESEUS_TENSOR_CHECK_CUDA(Ms_val, 2, batchSize, torch::kDouble);
 	TORCH_CHECK(Ms_val.size(1) == M_nnz);
-	TORCH_CHECK(vec.device().is_cuda());
-	TORCH_CHECK(vec.dim() == 2);
-	TORCH_CHECK(vec.size(0) == batchSize);
+	THESEUS_TENSOR_CHECK_CUDA(vec, 2, batchSize, vec.dtype());
 	TORCH_CHECK(vec.size(1) == M_numRows);
 	
 	auto xOptions = torch::TensorOptions().dtype(torch::kDouble).device(Ms_val.device());
@@ -350,25 +333,13 @@ void apply_damping(int batchSize,
 	int64_t M_numRows = M_rowPtr.size(0) - 1;
 	int64_t M_nnz = M_colInd.size(0);
 
-	TORCH_CHECK(M_rowPtr.device().is_cuda());
-	TORCH_CHECK(M_colInd.device().is_cuda());
-	TORCH_CHECK(Ms_val.device().is_cuda());
-	TORCH_CHECK(alpha.device().is_cuda());
-	TORCH_CHECK(beta.device().is_cuda());
-	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt);
-	TORCH_CHECK(M_colInd.dtype() == torch::kInt);
-	TORCH_CHECK(Ms_val.dtype() == torch::kDouble); // TODO: add support for float
-	TORCH_CHECK(alpha.dtype() == torch::kDouble);
-	TORCH_CHECK(beta.dtype() == torch::kDouble);
-	TORCH_CHECK(M_rowPtr.dim() == 1);
-	TORCH_CHECK(M_colInd.dim() == 1);
-	TORCH_CHECK(Ms_val.dim() == 2);
-	TORCH_CHECK(alpha.dim() == 1)
-	TORCH_CHECK(beta.dim() == 1)
-	TORCH_CHECK(Ms_val.size(0) == batchSize);
+	THESEUS_TENSOR_CHECK_CUDA(M_rowPtr, 1, M_rowPtr.size(0), torch::kInt);
+	THESEUS_TENSOR_CHECK_CUDA(M_colInd, 1, M_colInd.size(0), torch::kInt);
+	// TODO: add support for float
+	THESEUS_TENSOR_CHECK_CUDA(Ms_val, 2, batchSize, torch::kDouble);
 	TORCH_CHECK(Ms_val.size(1) == M_nnz);
-	TORCH_CHECK(alpha.size(0) == batchSize);
-	TORCH_CHECK(beta.size(0) == batchSize);
+	THESEUS_TENSOR_CHECK_CUDA(alpha, 1, batchSize, torch::kDouble);
+	THESEUS_TENSOR_CHECK_CUDA(beta, 1, batchSize, torch::kDouble);
 
 	// TODO: do experiments on choice of work group size
 	dim3 wgs(1, 16);

--- a/theseus/extlib/mat_mult.cu
+++ b/theseus/extlib/mat_mult.cu
@@ -318,7 +318,7 @@ __global__ void apply_damping_kernel(int batchSize,
                                 const int* M_rowPtr,
                                 const int* M_colInd,
                                 double* Ms_val,
-                                double alpha,
+                                double* alpha,
                                 double beta) {
 
 	int row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -334,7 +334,7 @@ __global__ void apply_damping_kernel(int batchSize,
 
 	for(int i = 0; i < srcRow_len; i++) {
 		if(srcRow_colInd[i] == row) {
-			srcRow_val[i] += alpha * srcRow_val[i] + beta;
+			srcRow_val[i] += alpha[batchIndex] * srcRow_val[i] + beta;
 		}
 	}
 }
@@ -344,7 +344,7 @@ void apply_damping(int batchSize,
                    const torch::Tensor& M_rowPtr,
                    const torch::Tensor& M_colInd,
                    const torch::Tensor& Ms_val,
-                   double alpha,
+                   const torch::Tensor& alpha,
                    double beta) {
 
 	int64_t M_numRows = M_rowPtr.size(0) - 1;
@@ -353,13 +353,17 @@ void apply_damping(int batchSize,
 	TORCH_CHECK(M_rowPtr.device().is_cuda());
 	TORCH_CHECK(M_colInd.device().is_cuda());
 	TORCH_CHECK(Ms_val.device().is_cuda());
+	TORCH_CHECK(alpha.device().is_cuda());
 	TORCH_CHECK(M_rowPtr.dtype() == torch::kInt);
 	TORCH_CHECK(M_colInd.dtype() == torch::kInt);
 	TORCH_CHECK(Ms_val.dtype() == torch::kDouble); // TODO: add support for float
+	TORCH_CHECK(alpha.dtype() == torch::kDouble);
 	TORCH_CHECK(M_rowPtr.dim() == 1);
 	TORCH_CHECK(M_colInd.dim() == 1);
 	TORCH_CHECK(Ms_val.dim() == 2);
+	TORCH_CHECK(alpha.dim() == 1)
 	TORCH_CHECK(Ms_val.size(0) == batchSize);
+	TORCH_CHECK(alpha.size(0) == batchSize);
 	TORCH_CHECK(Ms_val.size(1) == M_nnz);
 
 	// TODO: do experiments on choice of work group size
@@ -373,7 +377,7 @@ void apply_damping(int batchSize,
 	                                         M_rowPtr.data_ptr<int>(),
 	                                         M_colInd.data_ptr<int>(),
 	                                         Ms_val.data_ptr<double>(),
-	                                         alpha,
+	                                         alpha.data_ptr<double>(),
 	                                         beta);
 }
 

--- a/theseus/extlib/tests/test_baspacho.py
+++ b/theseus/extlib/tests/test_baspacho.py
@@ -80,8 +80,8 @@ def check_baspacho(
     f = s.create_numeric_decomposition(batch_size)
 
     f.add_MtM(A_val, A_rowPtr, A_colInd)
-    beta = 0.01
-    alpha = torch.rand(batch_size, device=dev, dtype=torch.double)
+    beta = 0.01 * torch.rand(batch_size, device=dev, dtype=torch.double)
+    alpha = torch.rand_like(beta)
     f.damp(alpha, beta)
     f.factor()
 
@@ -101,7 +101,7 @@ def check_baspacho(
     ]
     residuals = [
         (AtA_csr[i] + damp_diags[i]) @ sol[i].cpu().numpy()
-        + beta * sol[i].cpu().numpy()
+        + beta[i].item() * sol[i].cpu().numpy()
         - Atb[i].cpu().numpy()
         for i in range(batch_size)
     ]

--- a/theseus/extlib/tests/test_cusolver_lu_solver.py
+++ b/theseus/extlib/tests/test_cusolver_lu_solver.py
@@ -23,8 +23,10 @@ def check_lu_solver(
         return
     from theseus.extlib.cusolver_lu_solver import CusolverLUSolver
 
+    rng = torch.Generator()
+    rng.manual_seed(0)
     A_skel = random_sparse_binary_matrix(
-        num_rows, num_cols, fill, min_entries_per_col=3
+        num_rows, num_cols, fill, min_entries_per_col=3, rng=rng
     )
     A_num_cols = num_cols
     A_rowPtr = torch.tensor(A_skel.indptr, dtype=torch.int).cuda()

--- a/theseus/extlib/tests/test_mat_mult.py
+++ b/theseus/extlib/tests/test_mat_mult.py
@@ -16,8 +16,10 @@ def check_mat_mult(batch_size, num_rows, num_cols, fill, verbose=False):
         return
     from theseus.extlib.mat_mult import apply_damping, mat_vec, mult_MtM, tmat_vec
 
+    rng = torch.Generator()
+    rng.manual_seed(0)
     A_skel = random_sparse_binary_matrix(
-        num_rows, num_cols, fill, min_entries_per_col=3
+        num_rows, num_cols, fill, min_entries_per_col=3, rng=rng
     )
     A_num_cols = num_cols
     A_rowPtr = torch.tensor(A_skel.indptr, dtype=torch.int).cuda()

--- a/theseus/extlib/tests/test_mat_mult.py
+++ b/theseus/extlib/tests/test_mat_mult.py
@@ -71,7 +71,7 @@ def check_mat_mult(batch_size, num_rows, num_cols, fill, verbose=False):
         )
     )
     alpha = 0.3 * torch.rand(batch_size, dtype=torch.double).cuda()
-    beta = 0.7
+    beta = 0.7 * torch.rand(batch_size, dtype=torch.double).cuda()
     apply_damping(batch_size, AtA_num_cols, AtA_rowPtr, AtA_colInd, res, alpha, beta)
     new_diagonals = torch.tensor(
         np.array(
@@ -85,7 +85,8 @@ def check_mat_mult(batch_size, num_rows, num_cols, fill, verbose=False):
         )
     )
     assert new_diagonals.isclose(
-        old_diagonals * (1 + alpha.cpu().view(-1, 1)) + beta, atol=1e-10
+        old_diagonals * (1 + alpha.cpu().view(-1, 1)) + beta.cpu().view(-1, 1),
+        atol=1e-10,
     ).all()
 
     # test A * b

--- a/theseus/extlib/utils.h
+++ b/theseus/extlib/utils.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <torch/extension.h>
+
+
+// Various checks for tensor dimensions, dtype and devices
+#define THESEUS_BASE_TENSOR_CHECK(tensor, d, d1, dt)             \
+  do {                                                          \
+    TORCH_CHECK(tensor.dim() == d);                             \
+    TORCH_CHECK(tensor.size(0) == d1);                          \
+    TORCH_CHECK(tensor.dtype() == dt);                          \
+  } while (0)
+
+#define THESEUS_TENSOR_CHECK_CPU(tensor, d, d1, dt)         \
+  do {                                                          \
+    THESEUS_BASE_TENSOR_CHECK(tensor, d, d1, dt);                \
+    TORCH_CHECK(tensor.device().is_cpu());                      \
+  } while (0)
+
+#define THESEUS_TENSOR_CHECK_CUDA(tensor, d, d1, dt)        \
+  do {                                                          \
+    THESEUS_BASE_TENSOR_CHECK(tensor, d, d1, dt);                \
+    TORCH_CHECK(tensor.device().is_cuda());                     \
+  } while (0)
+

--- a/theseus/optimizer/autograd/baspacho_sparse_autograd.py
+++ b/theseus/optimizer/autograd/baspacho_sparse_autograd.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+from typing import Tuple, Optional
 import torch
 
 from ..linear_system import SparseStructure
@@ -82,7 +82,7 @@ class BaspachoSolveFunction(torch.autograd.Function):
         A_rowPtr: torch.Tensor = args[3]
         A_colInd: torch.Tensor = args[4]
         symbolic_decomposition: SymbolicDecomposition = args[5]
-        damping_alpha_beta: float = args[6]
+        damping_alpha_beta: Optional[Tuple[torch.Tensor, torch.Tensor]] = args[6]
 
         batch_size = A_val.shape[0]
 
@@ -91,6 +91,7 @@ class BaspachoSolveFunction(torch.autograd.Function):
         )
         numeric_decomposition.add_MtM(A_val, A_rowPtr, A_colInd)
         if damping_alpha_beta is not None:
+            print(damping_alpha_beta[0].shape, damping_alpha_beta[1].shape)
             numeric_decomposition.damp(*damping_alpha_beta)
         numeric_decomposition.factor()
 
@@ -191,8 +192,11 @@ class BaspachoSolveFunction(torch.autograd.Function):
             )
 
         # apply correction if there is a multiplicative damping
-        if ctx.damping_alpha_beta is not None and ctx.damping_alpha_beta[0] > 0.0:
-            alpha = ctx.damping_alpha_beta[0]
+        if (
+            ctx.damping_alpha_beta is not None
+            and (ctx.damping_alpha_beta[0] > 0.0).any()
+        ):
+            alpha = ctx.damping_alpha_beta[0].view(-1, 1)
             alpha2Hx = (alpha * 2.0) * H * ctx.x  # componentwise product
             A_grad -= ctx.A_val * alpha2Hx[:, ctx.A_colInd.type(torch.long)]
 

--- a/theseus/optimizer/autograd/baspacho_sparse_autograd.py
+++ b/theseus/optimizer/autograd/baspacho_sparse_autograd.py
@@ -91,7 +91,6 @@ class BaspachoSolveFunction(torch.autograd.Function):
         )
         numeric_decomposition.add_MtM(A_val, A_rowPtr, A_colInd)
         if damping_alpha_beta is not None:
-            print(damping_alpha_beta[0].shape, damping_alpha_beta[1].shape)
             numeric_decomposition.damp(*damping_alpha_beta)
         numeric_decomposition.factor()
 

--- a/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
+++ b/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+from typing import Optional, Tuple
 import torch
 
 from ..linear_system import SparseStructure
@@ -31,7 +31,7 @@ class LUCudaSolveFunction(torch.autograd.Function):
         A_rowPtr: torch.Tensor = args[3]
         A_colInd: torch.Tensor = args[4]
         solver_context: CusolverLUSolver = args[5]
-        damping_alpha_beta: float = args[6]
+        damping_alpha_beta: Optional[Tuple[torch.Tensor, torch.Tensor]] = args[6]
         check_factor_id: bool = args[7]
 
         AtA_rowPtr = solver_context.A_rowPtr
@@ -164,8 +164,11 @@ class LUCudaSolveFunction(torch.autograd.Function):
             )
 
         # apply correction if there is a multiplicative damping
-        if ctx.damping_alpha_beta is not None and ctx.damping_alpha_beta[0] > 0.0:
-            alpha = ctx.damping_alpha_beta[0]
+        if (
+            ctx.damping_alpha_beta is not None
+            and (ctx.damping_alpha_beta[0] > 0.0).any()
+        ):
+            alpha = ctx.damping_alpha_beta[0].view(-1, 1)
             alpha2Hx = (alpha * 2.0) * H * ctx.x  # componentwise product
             A_grad -= ctx.A_val * alpha2Hx[:, ctx.A_colInd.type(torch.long)]
 

--- a/theseus/optimizer/autograd/tests/__init__.py
+++ b/theseus/optimizer/autograd/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
+++ b/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
@@ -15,11 +15,9 @@ from theseus.utils import random_sparse_binary_matrix, split_into_param_sizes
 import theseus as th
 
 
-def check_sparse_backward_step(
-    batch_size, rows_to_cols_ratio, num_cols, param_size_range, fill, dev="cpu"
+def get_linearization_and_solver_for_random_sparse(
+    batch_size, rows_to_cols_ratio, num_cols, param_size_range, fill, dev, rng
 ):
-    torch.manual_seed(hash(str([batch_size, rows_to_cols_ratio, num_cols, fill])))
-
     # this is necessary assumption, so that the hessian can be full rank. actually we
     # add some damping to At*A's diagonal, so not really necessary
     assert rows_to_cols_ratio >= 1.0
@@ -36,29 +34,48 @@ def check_sparse_backward_step(
     linearization = solver.linearization
 
     A_skel = random_sparse_binary_matrix(
-        num_rows, num_cols, fill, min_entries_per_col=1
+        num_rows, num_cols, fill, min_entries_per_col=1, rng=rng
     )
     void_objective._batch_size = batch_size
     linearization.num_rows = num_rows
     linearization.num_cols = num_cols
     linearization.A_col_ind = A_skel.indices
     linearization.A_row_ptr = A_skel.indptr
-    linearization.A_val = torch.rand((batch_size, A_skel.nnz), dtype=torch.double).to(
-        dev
+    linearization.A_val = torch.rand(
+        (batch_size, A_skel.nnz), dtype=torch.double, device=dev, generator=rng
     )
-    linearization.b = torch.randn((batch_size, num_rows), dtype=torch.double).to(dev)
+    linearization.b = torch.randn(
+        (batch_size, num_rows), dtype=torch.double, device=dev, generator=rng
+    )
 
     # also need: var dims and var_start_cols (because baspacho is blockwise)
-    linearization.var_dims = split_into_param_sizes(num_cols, *param_size_range)
+    linearization.var_dims = split_into_param_sizes(
+        num_cols, *param_size_range, rng=rng
+    )
     linearization.var_start_cols = np.cumsum([0, *linearization.var_dims[:-1]])
 
+    return linearization, solver
+
+
+def check_sparse_backward_step(
+    batch_size, rows_to_cols_ratio, num_cols, param_size_range, fill, dev="cpu"
+):
+    rng = torch.Generator(device=dev)
+    rng.manual_seed(hash(str([batch_size, rows_to_cols_ratio, num_cols, fill])))
+
+    linearization, solver = get_linearization_and_solver_for_random_sparse(
+        batch_size, rows_to_cols_ratio, num_cols, param_size_range, fill, dev, rng
+    )
     linearization.A_val.requires_grad = True
     linearization.b.requires_grad = True
     # Only need this line for the test since the objective is a mock
     solver.reset(dev=dev)
+    alpha = torch.rand(batch_size, device=dev, dtype=torch.double, generator=rng)
+    if torch.rand(1, device=rng.device, generator=rng).item() < 0.5:
+        alpha = torch.zeros_like(alpha)  # also test non-ellipsoidal
     damping_alpha_beta = (
-        0.023 * torch.rand_like(linearization.A_val[:, 0]),
-        0.157 * torch.rand_like(linearization.A_val[:, 0]),
+        alpha,
+        torch.rand(batch_size, device=dev, dtype=torch.double, generator=rng),
     )
     inputs = (
         linearization.A_val,

--- a/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
+++ b/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
@@ -56,7 +56,10 @@ def check_sparse_backward_step(
     linearization.b.requires_grad = True
     # Only need this line for the test since the objective is a mock
     solver.reset(dev=dev)
-    damping_alpha_beta = (0.023, 0.157)
+    damping_alpha_beta = (
+        0.023 * torch.rand_like(linearization.A_val[:, 0]),
+        0.157 * torch.rand_like(linearization.A_val[:, 0]),
+    )
     inputs = (
         linearization.A_val,
         linearization.b,

--- a/theseus/optimizer/autograd/tests/test_lu_cuda_sparse_backward.py
+++ b/theseus/optimizer/autograd/tests/test_lu_cuda_sparse_backward.py
@@ -53,7 +53,10 @@ def test_sparse_backward_step():
     linearization.b.requires_grad = True
     # Only need this line for the test since the objective is a mock
     solver.reset(batch_size=batch_size)
-    damping_alpha_beta = (0.5, 1.3)
+    damping_alpha_beta = (
+        0.5 * torch.rand_like(linearization.A_val[:, 0]),
+        1.3 * torch.rand_like(linearization.A_val[:, 0]),
+    )
     inputs = (
         linearization.A_val,
         linearization.b,

--- a/theseus/optimizer/linear/baspacho_sparse_solver.py
+++ b/theseus/optimizer/linear/baspacho_sparse_solver.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 import torch
 
@@ -12,6 +12,7 @@ from theseus.optimizer import Linearization, SparseLinearization
 from theseus.optimizer.autograd import BaspachoSolveFunction
 
 from .linear_solver import LinearSolver
+from .utils import convert_to_alpha_beta_damping_tensors
 from scipy.sparse import csr_matrix
 import numpy as np
 
@@ -97,7 +98,7 @@ class BaspachoSparseSolver(LinearSolver):
 
     def solve(
         self,
-        damping: Optional[float] = None,
+        damping: Optional[Union[float, torch.Tensor]] = None,
         ellipsoidal_damping: bool = True,
         damping_eps: float = 1e-8,
         **kwargs,
@@ -110,10 +111,16 @@ class BaspachoSparseSolver(LinearSolver):
         if damping is None:
             damping_alpha_beta = None
         else:
-            # See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
-            # https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
-            damping_alpha_beta = (
-                (damping, damping_eps) if ellipsoidal_damping else (0.0, damping)
+            A_val = (
+                self.linearization.A_val
+            )  # only used to get batch size, device, dtype
+            damping_alpha_beta = convert_to_alpha_beta_damping_tensors(
+                damping,
+                damping_eps,
+                ellipsoidal_damping,
+                batch_size=A_val.shape[0],
+                device=A_val.device,
+                dtype=A_val.dtype,
             )
 
         return BaspachoSolveFunction.apply(

--- a/theseus/optimizer/linear/baspacho_sparse_solver.py
+++ b/theseus/optimizer/linear/baspacho_sparse_solver.py
@@ -111,16 +111,13 @@ class BaspachoSparseSolver(LinearSolver):
         if damping is None:
             damping_alpha_beta = None
         else:
-            A_val = (
-                self.linearization.A_val
-            )  # only used to get batch size, device, dtype
             damping_alpha_beta = convert_to_alpha_beta_damping_tensors(
                 damping,
                 damping_eps,
                 ellipsoidal_damping,
-                batch_size=A_val.shape[0],
-                device=A_val.device,
-                dtype=A_val.dtype,
+                batch_size=self.linearization.A_val.shape[0],
+                device=self.linearization.A_val.device,
+                dtype=self.linearization.A_val.dtype,
             )
 
         return BaspachoSolveFunction.apply(

--- a/theseus/optimizer/linear/cholmod_sparse_solver.py
+++ b/theseus/optimizer/linear/cholmod_sparse_solver.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 import torch
 
@@ -47,7 +47,11 @@ class CholmodSparseSolver(LinearSolver):
         # the `damping` has the purpose of (optionally) improving conditioning
         self._damping: float = damping
 
-    def solve(self, damping: Optional[float] = None, **kwargs) -> torch.Tensor:
+    def solve(
+        self, damping: Optional[Union[float, torch.Tensor]] = None, **kwargs
+    ) -> torch.Tensor:
+        if damping is not None and not isinstance(damping, float):
+            raise ValueError("CholmodSparseSolver only supports scalar damping.")
         damping = damping or self._damping
         if not isinstance(self.linearization, SparseLinearization):
             raise RuntimeError(

--- a/theseus/optimizer/linear/dense_solver.py
+++ b/theseus/optimizer/linear/dense_solver.py
@@ -51,14 +51,13 @@ class DenseSolver(LinearSolver):
 
         # See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
         # https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
+        damping = matrix.new_tensor(damping)
         if ellipsoidal:
-            if isinstance(damping, torch.Tensor):
-                damping = damping.view(-1, 1)
+            damping = damping.view(-1, 1)
             # Add eps to guard against ill-conditioned matrix
             damped_D = torch.diag_embed(damping * matrix.diagonal(dim1=1, dim2=2) + eps)
         else:
-            if isinstance(damping, torch.Tensor):
-                damping = damping.view(-1, 1, 1)
+            damping = damping.view(-1, 1, 1)
             damped_D = damping * torch.eye(
                 n, device=matrix.device, dtype=matrix.dtype
             ).unsqueeze(0)

--- a/theseus/optimizer/linear/dense_solver.py
+++ b/theseus/optimizer/linear/dense_solver.py
@@ -51,7 +51,7 @@ class DenseSolver(LinearSolver):
 
         # See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
         # https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
-        damping = matrix.new_tensor(damping)
+        damping = torch.as_tensor(damping).to(device=matrix.device, dtype=matrix.dtype)
         if ellipsoidal:
             damping = damping.view(-1, 1)
             # Add eps to guard against ill-conditioned matrix

--- a/theseus/optimizer/linear/dense_solver.py
+++ b/theseus/optimizer/linear/dense_solver.py
@@ -5,7 +5,7 @@
 
 import abc
 import warnings
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 import torch
 import torch.linalg
@@ -37,7 +37,7 @@ class DenseSolver(LinearSolver):
     @staticmethod
     def _apply_damping(
         matrix: torch.Tensor,
-        damping: float,
+        damping: Union[float, torch.Tensor],
         ellipsoidal: bool = True,
         eps: float = 1e-8,
     ) -> torch.Tensor:
@@ -52,9 +52,13 @@ class DenseSolver(LinearSolver):
         # See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
         # https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
         if ellipsoidal:
+            if isinstance(damping, torch.Tensor):
+                damping = damping.view(-1, 1)
             # Add eps to guard against ill-conditioned matrix
             damped_D = torch.diag_embed(damping * matrix.diagonal(dim1=1, dim2=2) + eps)
         else:
+            if isinstance(damping, torch.Tensor):
+                damping = damping.view(-1, 1, 1)
             damped_D = damping * torch.eye(
                 n, device=matrix.device, dtype=matrix.dtype
             ).unsqueeze(0)
@@ -64,11 +68,11 @@ class DenseSolver(LinearSolver):
         self,
         Atb: torch.Tensor,
         AtA: torch.Tensor,
-        damping: Optional[float] = None,
+        damping: Optional[Union[float, torch.Tensor]] = None,
         ellipsoidal_damping: bool = True,
         damping_eps: float = 1e-8,
     ) -> torch.Tensor:
-        if damping:
+        if damping is not None:
             AtA = DenseSolver._apply_damping(
                 AtA, damping, ellipsoidal=ellipsoidal_damping, eps=damping_eps
             )
@@ -80,7 +84,7 @@ class DenseSolver(LinearSolver):
 
     def solve(
         self,
-        damping: Optional[float] = None,
+        damping: Optional[Union[float, torch.Tensor]] = None,
         ellipsoidal_damping: bool = True,
         damping_eps: float = 1e-8,
         **kwargs,

--- a/theseus/optimizer/linear/linear_solver.py
+++ b/theseus/optimizer/linear/linear_solver.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 import torch
 
@@ -27,5 +27,7 @@ class LinearSolver(abc.ABC):
         )
 
     @abc.abstractmethod
-    def solve(self, damping: Optional[float] = None, **kwargs) -> torch.Tensor:
+    def solve(
+        self, damping: Optional[Union[float, torch.Tensor]] = None, **kwargs
+    ) -> torch.Tensor:
         pass

--- a/theseus/optimizer/linear/lu_cuda_sparse_solver.py
+++ b/theseus/optimizer/linear/lu_cuda_sparse_solver.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 import torch
 
@@ -90,17 +90,19 @@ class LUCudaSparseSolver(LinearSolver):
 
     def solve(
         self,
-        damping: Optional[float] = None,
+        damping: Optional[Union[float, torch.Tensor]] = None,
         ellipsoidal_damping: bool = True,
         damping_eps: float = 1e-8,
         **kwargs,
     ) -> torch.Tensor:
+        if damping is not None and not isinstance(damping, float):
+            raise ValueError("LUCudaSparseSolver only supports scalar damping.")
         if self._auto_reset:
             if self._solver_contexts[0].batch_size != self._objective.batch_size:
                 self.reset(self._objective.batch_size)
         if not isinstance(self.linearization, SparseLinearization):
             raise RuntimeError(
-                "CholmodSparseSolver only works with theseus.optimizer.SparseLinearization."
+                "LUCudaSparseSolver only works with theseus.optimizer.SparseLinearization."
             )
 
         self._last_solver_context = (

--- a/theseus/optimizer/linear/lu_cuda_sparse_solver.py
+++ b/theseus/optimizer/linear/lu_cuda_sparse_solver.py
@@ -111,16 +111,13 @@ class LUCudaSparseSolver(LinearSolver):
         if damping is None:
             damping_alpha_beta = None
         else:
-            A_val = (
-                self.linearization.A_val
-            )  # only used to get batch size, device, dtype
             damping_alpha_beta = convert_to_alpha_beta_damping_tensors(
                 damping,
                 damping_eps,
                 ellipsoidal_damping,
-                batch_size=A_val.shape[0],
-                device=A_val.device,
-                dtype=A_val.dtype,
+                batch_size=self.linearization.A_val.shape[0],
+                device=self.linearization.A_val.device,
+                dtype=self.linearization.A_val.dtype,
             )
 
         return LUCudaSolveFunction.apply(

--- a/theseus/optimizer/linear/lu_cuda_sparse_solver.py
+++ b/theseus/optimizer/linear/lu_cuda_sparse_solver.py
@@ -12,7 +12,7 @@ from theseus.optimizer import Linearization, SparseLinearization
 from theseus.optimizer.autograd import LUCudaSolveFunction
 
 from .linear_solver import LinearSolver
-from .sparse_utils import convert_to_alpha_beta_damping
+from .utils import convert_to_alpha_beta_damping_tensors
 
 
 class LUCudaSparseSolver(LinearSolver):
@@ -114,7 +114,7 @@ class LUCudaSparseSolver(LinearSolver):
             A_val = (
                 self.linearization.A_val
             )  # only used to get batch size, device, dtype
-            damping_alpha_beta = convert_to_alpha_beta_damping(
+            damping_alpha_beta = convert_to_alpha_beta_damping_tensors(
                 damping,
                 damping_eps,
                 ellipsoidal_damping,

--- a/theseus/optimizer/linear/sparse_utils.py
+++ b/theseus/optimizer/linear/sparse_utils.py
@@ -1,0 +1,25 @@
+from typing import Tuple, Union
+import torch
+
+
+# See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
+# https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
+def convert_to_alpha_beta_damping(
+    damping: Union[float, torch.Tensor],
+    damping_eps: float,
+    ellipsoidal_damping: bool,
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    damping = torch.as_tensor(damping).to(device=device, dtype=dtype)
+    if damping.ndim > 1:
+        raise ValueError("Damping must be a float or a 1-D tensor.")
+    damping = damping.view(-1)  # this expands floats with ndim = 0
+    if batch_size != damping.shape[0]:
+        damping = damping.expand(batch_size)
+    return (
+        (damping, damping_eps * torch.ones_like(damping))
+        if ellipsoidal_damping
+        else (torch.zeros_like(damping), damping)
+    )

--- a/theseus/optimizer/linear/tests/test_baspacho_sparse_solver.py
+++ b/theseus/optimizer/linear/tests/test_baspacho_sparse_solver.py
@@ -63,14 +63,12 @@ def check_sparse_solver(
         Ai = torch.tensor(csrAi.todense(), dtype=torch.double)
         ata = Ai.T @ Ai
         b = linearization.b[i].cpu()
-        atb = torch.Tensor(csrAi.transpose() @ b)
+        atb = torch.DoubleTensor(csrAi.transpose() @ b)
 
         # the linear system solved is with matrix AtA
         solved_xi_cpu = solved_x[i].cpu()
         atb_check = ata @ solved_xi_cpu + damping * solved_xi_cpu
-
-        max_offset = torch.norm(atb - atb_check, p=float("inf"))
-        assert max_offset < 1e-4
+        torch.testing.assert_close(atb, atb_check, atol=1e-3, rtol=1e-3)
 
 
 @run_if_baspacho()

--- a/theseus/optimizer/linear/tests/test_lu_cuda_sparse_solver.py
+++ b/theseus/optimizer/linear/tests/test_lu_cuda_sparse_solver.py
@@ -27,7 +27,7 @@ def _build_sparse_mat(batch_size, rng):
 @pytest.mark.parametrize("float_damping", [True, False])
 def test_sparse_solver(batch_size: int, float_damping: bool):
     rng = torch.Generator()
-    rng.manual_seed(37)
+    rng.manual_seed(0)
     if not torch.cuda.is_available():
         return
 

--- a/theseus/optimizer/linear/utils.py
+++ b/theseus/optimizer/linear/utils.py
@@ -15,9 +15,10 @@ def convert_to_alpha_beta_damping_tensors(
     damping = torch.as_tensor(damping).to(device=device, dtype=dtype)
     if damping.ndim > 1:
         raise ValueError("Damping must be a float or a 1-D tensor.")
-    damping = damping.view(-1)  # this expands floats with ndim = 0
-    if batch_size != damping.shape[0]:
-        damping = damping.expand(batch_size)
+    if damping.ndim == 0 or damping.shape[0] == 1 and batch_size != 1:
+        # Our damp kernel does not like expand, since it may try
+        # to access indices beyond what's actually stored in this tensor
+        damping = damping.repeat(batch_size)
     return (
         (damping, damping_eps * torch.ones_like(damping))
         if ellipsoidal_damping

--- a/theseus/optimizer/linear/utils.py
+++ b/theseus/optimizer/linear/utils.py
@@ -4,7 +4,7 @@ import torch
 
 # See Nocedal and Wright, Numerical Optimization, pp. 260 and 261
 # https://www.csie.ntu.edu.tw/~r97002/temp/num_optimization.pdf
-def convert_to_alpha_beta_damping(
+def convert_to_alpha_beta_damping_tensors(
     damping: Union[float, torch.Tensor],
     damping_eps: float,
     ellipsoidal_damping: bool,

--- a/theseus/optimizer/linear/utils.py
+++ b/theseus/optimizer/linear/utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 from typing import Tuple, Union
 import torch
 

--- a/theseus/optimizer/nonlinear/levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/levenberg_marquardt.py
@@ -3,23 +3,41 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 import torch
 
 from theseus.core import Objective
 from theseus.optimizer import Linearization
-from theseus.optimizer.linear import DenseSolver, LinearSolver, LUCudaSparseSolver
+from theseus.optimizer.linear import (
+    CholeskyDenseSolver,
+    LinearSolver,
+    LUCudaSparseSolver,
+    LUDenseSolver,
+)
 
 from .nonlinear_least_squares import NonlinearLeastSquares
 
-_LM_ALLOWED_ELLIPS_DAMP_SOLVERS = [DenseSolver, LUCudaSparseSolver]
+_LM_ALLOWED_ELLIPS_DAMP_SOLVERS: List[Type[LinearSolver]] = [
+    CholeskyDenseSolver,
+    LUDenseSolver,
+    LUCudaSparseSolver,
+]
 _EDAMP_SOLVERS_STR = ",".join(c.__name__ for c in _LM_ALLOWED_ELLIPS_DAMP_SOLVERS)
+_LM_ALLOWED_ADAPTIVE_DAMP_SOLVERS: List[Type[LinearSolver]] = [
+    CholeskyDenseSolver,
+    LUDenseSolver,
+]
+_ADAPT_DAMP_SOLVERS_STR = ",".join(
+    c.__name__ for c in _LM_ALLOWED_ADAPTIVE_DAMP_SOLVERS
+)
 
 
-def _check_ellipsoidal_damping_cls(linear_solver: LinearSolver):
+def _check_linear_solver(
+    linear_solver: LinearSolver, allowed_solvers: Sequence[Type[LinearSolver]]
+):
     good = False
-    for lsc in _LM_ALLOWED_ELLIPS_DAMP_SOLVERS:
+    for lsc in allowed_solvers:
         if isinstance(linear_solver, lsc):
             good = True
     return good
@@ -55,35 +73,54 @@ class LevenbergMarquardt(NonlinearLeastSquares):
             step_size=step_size,
             **kwargs,
         )
-        self._allows_ellipsoidal = _check_ellipsoidal_damping_cls(self.linear_solver)
-        self._damping = 0.001
+        self._allows_ellipsoidal = _check_linear_solver(
+            self.linear_solver, _LM_ALLOWED_ELLIPS_DAMP_SOLVERS
+        )
+        self._allows_adaptive = _check_linear_solver(
+            self.linear_solver, _LM_ALLOWED_ADAPTIVE_DAMP_SOLVERS
+        )
+        self._damping: Union[float, torch.Tensor] = 0.001
         self._ellipsoidal_damping = False
+        self._adaptive_damping = False
 
     def reset(
         self,
         damping: float = 1e-3,
         ellipsoidal_damping: bool = False,
+        adaptive_damping: bool = False,
         **kwargs,
     ) -> None:
-        self._damping = damping
         if ellipsoidal_damping and not self._allows_ellipsoidal:
             raise NotImplementedError(
                 f"Ellipsoidal damping is only supported by solvers with type "
                 f"[{_EDAMP_SOLVERS_STR}]."
             )
         self._ellipsoidal_damping = ellipsoidal_damping
+        if adaptive_damping and not self._allows_adaptive:
+            raise NotImplementedError(
+                f"Adaptive damping is only supported by solvers with type "
+                f"[{_ADAPT_DAMP_SOLVERS_STR}]."
+            )
+        if adaptive_damping:
+            self._damping = damping * torch.ones(
+                self.objective.batch_size,
+                device=self.objective.device,
+                dtype=self.objective.dtype,
+            )
+        else:
+            self._damping = damping
 
     def compute_delta(
         self,
         damping_eps: Optional[float] = None,
         **kwargs,
     ) -> torch.Tensor:
-        if damping_eps and not self._allows_ellipsoidal:
+        if damping_eps is not None and not self._allows_ellipsoidal:
             raise NotImplementedError(
                 f"damping eps is only supported by solvers with type "
                 f"[{_EDAMP_SOLVERS_STR}]."
             )
-        damping_eps = damping_eps or 1e-8
+        damping_eps = damping_eps if damping_eps is not None else 1e-8
 
         return self.linear_solver.solve(
             damping=self._damping,

--- a/theseus/optimizer/nonlinear/levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/levenberg_marquardt.py
@@ -10,6 +10,7 @@ import torch
 from theseus.core import Objective
 from theseus.optimizer import DenseLinearization, Linearization
 from theseus.optimizer.linear import (
+    BaspachoSparseSolver,
     CholeskyDenseSolver,
     LinearSolver,
     LUCudaSparseSolver,
@@ -25,7 +26,9 @@ _LM_ALLOWED_ELLIPS_DAMP_SOLVERS: List[Type[LinearSolver]] = [
 ]
 _EDAMP_SOLVERS_STR = ",".join(c.__name__ for c in _LM_ALLOWED_ELLIPS_DAMP_SOLVERS)
 _LM_ALLOWED_ADAPTIVE_DAMP_SOLVERS: List[Type[LinearSolver]] = [
+    BaspachoSparseSolver,
     CholeskyDenseSolver,
+    LUCudaSparseSolver,
     LUDenseSolver,
 ]
 _ADAPT_DAMP_SOLVERS_STR = ",".join(

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -373,6 +373,7 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
         end_iter_callback: Optional[EndIterCallbackType] = None,
         **kwargs,
     ) -> OptimizerInfo:
+        self.reset(**kwargs)
         backward_mode = BackwardMode.resolve(backward_mode)
         with torch.no_grad():
             info = self._init_info(
@@ -453,3 +454,9 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     @abc.abstractmethod
     def compute_delta(self, **kwargs) -> torch.Tensor:
         pass
+
+    # Resets any internal state needed by the optimizer for a new optimization
+    # problem. Optimizer loop will pass all optimizer kwargs to this method.
+    def reset(self, **kwargs) -> None:
+        pass
+

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -462,6 +462,7 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
 
     # Resets any internal state needed by the optimizer for a new optimization
     # problem. Optimizer loop will pass all optimizer kwargs to this method.
+    # Deliberately not abstract, since some optimizers might not need this
     def reset(self, **kwargs) -> None:
         pass
 
@@ -473,7 +474,7 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     ) -> None:
         self._update_state_impl(last_err, new_err, delta)
 
-    # Deliberately not abstract since, some optimizers might not need this
+    # Deliberately not abstract, since some optimizers might not need this
     def _update_state_impl(
         self, last_err: torch.Tensor, new_err: torch.Tensor, delta: torch.Tensor
     ) -> None:

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -336,6 +336,9 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
             with torch.no_grad():
                 err = self.objective.error_squared_norm() / 2
                 self._update_info(info, it_, err, converged_indices)
+                self.update_optimizer_state(
+                    last_err=info.last_err, new_err=err, delta=delta
+                )
                 if verbose:
                     print(
                         f"Nonlinear optimizer. Iteration: {it_+1}. "
@@ -460,3 +463,16 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     def reset(self, **kwargs) -> None:
         pass
 
+    # Called at the end of every optimizer step to update any internal state
+    # of the optimizer
+    @torch.no_grad()
+    def update_optimizer_state(
+        self, last_err: torch.Tensor, new_err: torch.Tensor, delta: torch.Tensor
+    ) -> None:
+        self._update_state_impl(last_err, new_err, delta)
+
+    # Deliberately not abstract since, some optimizers might not need this
+    def _update_state_impl(
+        self, last_err: torch.Tensor, new_err: torch.Tensor, delta: torch.Tensor
+    ) -> None:
+        pass

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -339,7 +339,7 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
                 err = self.objective.error_squared_norm() / 2
                 self._update_info(info, it_, err, converged_indices)
                 self.update_optimizer_state(
-                    last_err=info.last_err, new_err=err, delta=delta
+                    last_err=info.last_err, new_err=err, delta=delta, **kwargs
                 )
                 if verbose:
                     print(
@@ -470,12 +470,20 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     # of the optimizer
     @torch.no_grad()
     def update_optimizer_state(
-        self, last_err: torch.Tensor, new_err: torch.Tensor, delta: torch.Tensor
+        self,
+        last_err: torch.Tensor,
+        new_err: torch.Tensor,
+        delta: torch.Tensor,
+        **kwargs,
     ) -> None:
-        self._update_state_impl(last_err, new_err, delta)
+        self._update_state_impl(last_err, new_err, delta, **kwargs)
 
     # Deliberately not abstract, since some optimizers might not need this
     def _update_state_impl(
-        self, last_err: torch.Tensor, new_err: torch.Tensor, delta: torch.Tensor
+        self,
+        last_err: torch.Tensor,
+        new_err: torch.Tensor,
+        delta: torch.Tensor,
+        **kwargs,
     ) -> None:
         pass

--- a/theseus/optimizer/nonlinear/tests/test_levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/tests/test_levenberg_marquardt.py
@@ -8,7 +8,7 @@ import torch
 
 import theseus as th
 
-from .common import run_nonlinear_least_squares_check
+from theseus.optimizer.nonlinear.tests.common import run_nonlinear_least_squares_check
 
 
 @pytest.fixture
@@ -20,18 +20,20 @@ def mock_objective():
     return objective
 
 
-def test_levenberg_marquartd():
-    for ellipsoidal_damping in [True, False]:
-        for damping in [0, 0.001, 0.01, 0.1]:
-            run_nonlinear_least_squares_check(
-                th.LevenbergMarquardt,
-                {
-                    "damping": damping,
-                    "ellipsoidal_damping": ellipsoidal_damping,
-                    "damping_eps": 0.0,
-                },
-                singular_check=damping < 0.001,
-            )
+@pytest.mark.parametrize("damping", [0, 0.001, 0.01, 0.1])
+@pytest.mark.parametrize("ellipsoidal_damping", [True, False])
+@pytest.mark.parametrize("adaptive_damping", [True, False])
+def test_levenberg_marquardt(damping, ellipsoidal_damping, adaptive_damping):
+    run_nonlinear_least_squares_check(
+        th.LevenbergMarquardt,
+        {
+            "damping": damping,
+            "ellipsoidal_damping": ellipsoidal_damping,
+            "adaptive_damping": adaptive_damping,
+            "damping_eps": 0.0,
+        },
+        singular_check=damping < 0.001,
+    )
 
 
 def test_ellipsoidal_damping_compatibility(mock_objective):

--- a/theseus/optimizer/nonlinear/tests/test_levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/tests/test_levenberg_marquardt.py
@@ -20,7 +20,7 @@ def mock_objective():
     return objective
 
 
-@pytest.mark.parametrize("damping", [0, 0.001, 0.01, 0.1])
+@pytest.mark.parametrize("damping", [0.0, 0.001, 0.01, 0.1])
 @pytest.mark.parametrize("ellipsoidal_damping", [True, False])
 @pytest.mark.parametrize("adaptive_damping", [True, False])
 def test_levenberg_marquardt(damping, ellipsoidal_damping, adaptive_damping):

--- a/theseus/utils/sparse_matrix_utils.py
+++ b/theseus/utils/sparse_matrix_utils.py
@@ -2,41 +2,56 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+from typing import List
 from scipy.sparse import csr_matrix, lil_matrix
 import torch
 
 
-def random_sparse_binary_matrix(rows, cols, fill, min_entries_per_col) -> csr_matrix:
+def random_sparse_binary_matrix(
+    rows: int, cols: int, fill: float, min_entries_per_col: int, rng: torch.Generator
+) -> csr_matrix:
     retv = lil_matrix((rows, cols))
 
     if min_entries_per_col > 0:
         min_entries_per_col = min(rows, min_entries_per_col)
-        rows_array = torch.arange(rows)
+        rows_array = torch.arange(rows, device=rng.device)
         rows_array_f = rows_array.to(dtype=torch.float)
         for c in range(cols):
-            row_selection = rows_array[rows_array_f.multinomial(min_entries_per_col)]
+            row_selection = rows_array[
+                rows_array_f.multinomial(min_entries_per_col, generator=rng)
+            ].cpu()
             for r in row_selection:
                 retv[r, c] = 1.0
 
     # make sure last row is non-empty, so: len(indptr) = rows+1
-    retv[rows - 1, int(torch.randint(cols, ()))] = 1.0
+    retv[rows - 1, int(torch.randint(cols, (), device=rng.device, generator=rng))] = 1.0
 
     num_entries = int(fill * rows * cols)
     while retv.getnnz() < num_entries:
-        col = int(torch.randint(cols, ()))
-        row = int(torch.randint(rows, ()))
+        col = int(torch.randint(cols, (), device=rng.device, generator=rng))
+        row = int(torch.randint(rows, (), device=rng.device, generator=rng))
         retv[row, col] = 1.0
 
     return retv.tocsr()
 
 
-def split_into_param_sizes(n, param_size_range_min, param_size_range_max):
+def split_into_param_sizes(
+    n: int, param_size_range_min: int, param_size_range_max: int, rng: torch.Generator
+) -> List[int]:
     paramSizes = []
     tot = 0
     while tot < n:
         newParam = min(
-            int(torch.randint(param_size_range_min, param_size_range_max, ())), n - tot
+            int(
+                torch.randint(
+                    param_size_range_min,
+                    param_size_range_max,
+                    (),
+                    device=rng.device,
+                    generator=rng,
+                )
+            ),
+            n - tot,
         )
         tot += newParam
         paramSizes.append(newParam)


### PR DESCRIPTION
This PR adds adaptive damping for LM, based on Section 4 of [this](https://people.duke.edu/~hpgavin/ce281/lm.pdf) reference. It includes a number of features:

- Allow independent step sizes for each batch element (not used in this PR).
- Include a `reset()` method for nonlinear optimizers that's called at the start of each optimization. We could also have it call the linear solver's reset method, although in some of the current sparse solvers this is costly (@maurimo to confirm).
- Include a `update_optimizer_step()` method for nonlinear optimizers. 
- Add an implementation of the above for LM to allow adaptive damping.

This feature is currently only compatible with dense solvers. @maurimo how likely is that we could add support for this in the sparse solvers?

As an added bonus of this PR, once merged it should be easier to implement dogleg, learnable damping, and more sophisticated line search.  