### PR TITLE
Cleaned up Baspacho install, tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Our implementation provides an easy to use interface to build custom optimizatio
 - [Second-order nonlinear optimizers](https://github.com/facebookresearch/theseus/tree/main/theseus/optimizer/nonlinear)
     - Gauss-Newton, Levenberg–Marquardt
 - [Linear solvers](https://github.com/facebookresearch/theseus/tree/main/theseus/optimizer/linear)
-    - Dense: Cholesky, LU; Sparse: CHOLMOD, LU
+    - Dense: Cholesky, LU; Sparse: CHOLMOD, LU, [BaSpaCho](https://github.com/facebookresearch/baspacho)
 - [Commonly used costs](https://github.com/facebookresearch/theseus/tree/main/theseus/embodied), [AutoDiffCostFunction](https://github.com/facebookresearch/theseus/blob/main/theseus/core/cost_function.py), [RobustCostFunction](https://github.com/facebookresearch/theseus/blob/main/theseus/core/robust_cost_function.py)
 - [Lie groups](https://github.com/facebookresearch/theseus/tree/main/theseus/geometry)
 - [Robot kinematics](https://github.com/facebookresearch/theseus/blob/main/theseus/embodied/kinematics/kinematics_model.py)
@@ -97,6 +97,7 @@ For other CUDA versions, consider installing from source or using our
 [build script](https://github.com/facebookresearch/theseus/blob/main/build_scripts/build_wheel.sh).
 
 #### **From source**
+The simplest way to install Theseus from source is by running
 ```bash
 git clone https://github.com/facebookresearch/theseus.git && cd theseus
 pip install -e .
@@ -107,19 +108,27 @@ pip install -e ".[dev]"
 ```
 and follow the more detailed instructions in [CONTRIBUTING](https://github.com/facebookresearch/theseus/blob/main/CONTRIBUTING.md).
 
-Compilation from source supports is affected by the following enviroment variables:
-* `BASPACHO_ROOT_DIR`: root dir of [BaSpaCho](https://github.com/facebookresearch/baspacho) sparse solver, which must be already
-  built with binaries in the subdirectory `build`.
-* `THESEUS_FORCE_CUDA` (1 or 0): if set, forces enabling or disabling Cuda support regardless of system's `torch.cuda.is_available()`.
+**Installing BaSpaCho extensions from source**
+
+By default, installing from source doesn't include our BaSpaCho sparse solver extension. For this, follow these steps:
+
+1. Compile BaSpaCho from source following instructions [here](https://github.com/facebookresearch/baspacho). We recommend using flags `-DBLA_STATIC=ON -DBUILD_SHARED_LIBS=OFF`.
+2. Run
+    
+    ```bash
+    git clone https://github.com/facebookresearch/theseus.git && cd theseus
+    BASPACHO_ROOT_DIR=<path/to/root/baspacho/dir> pip install -e .
+    ```
+    
+    where the BaSpaCho root dir must have the binaries in the subdirectory `build`.
 
 ### Running unit tests (requires `dev` installation)
 ```bash
 python -m pytest theseus
 ```
 By default, unit tests include tests for our CUDA extensions. You can add the option `-m "not cudaext"`
-to skip them when installing without CUDA support.
-The tests for sparse solver BaSpaCho are automatically skipped when the extlib is not compiled, the marker
-`-m baspacho` can be used to manually select/deselect the tests depending on it.
+to skip them when installing without CUDA support. Additionally, the tests for sparse solver BaSpaCho are automatically 
+skipped when its extlib is not compiled.
 
 
 ## Examples

--- a/build_scripts/build_wheel.sh
+++ b/build_scripts/build_wheel.sh
@@ -111,7 +111,6 @@ for PYTHON_VERSION in 3.9; do
     echo $(pwd)
     DOCKER_NAME=theseus_${PYTHON_VERSION}
     sudo docker build -t "${DOCKER_NAME}_img" .
-    echo "sudo docker run --name ${DOCKER_NAME} ${DOCKER_NAME}_img"
     sudo docker run --name ${DOCKER_NAME} ${DOCKER_NAME}_img
 
     # Copy the wheel to host

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -29,7 +29,7 @@ For other CUDA versions, consider installing from source or using our
 
 From source
 """""""""""
-To install from source code, you can use
+The simplest way to install Theseus from source is by running
 
 .. code-block:: bash
 
@@ -45,6 +45,20 @@ If you are interested in contributing to ``theseus``, instead install using
 
 and follow the more detailed instructions in `CONTRIBUTING <https://github.com/facebookresearch/theseus/blob/main/CONTRIBUTING.md>`_.
 
+**Installing BaSpaCho extensions from source**
+By default, installing from source doesn't include our BaSpaCho sparse 
+solver extension. For this, follow these steps:
+
+1. Compile BaSpaCho from source following instructions `here <https://github.com/facebookresearch/baspacho>`_. We recommend using flags `-DBLA_STATIC=ON -DBUILD_SHARED_LIBS=OFF`.
+2. Run 
+
+    .. code-block:: bash
+
+    git clone https://github.com/facebookresearch/theseus.git && cd theseus
+    BASPACHO_ROOT_DIR=<path/to/root/baspacho/dir> pip install -e .
+
+    where the BaSpaCho root dir must have binaries in the subdirectory `build`.
+
 Unit tests
 """"""""""
 With ``dev`` installation, you can run unit tests via
@@ -54,9 +68,8 @@ With ``dev`` installation, you can run unit tests via
     python -m pytest theseus
 
 By default, unit tests include tests for our CUDA extensions. You can add the option `-m "not cudaext"`
-to skip them when installing without CUDA support.
-The tests for sparse solver BaSpaCho are automatically skipped when the extlib is not compiled, the marker
-`-m baspacho` can be used to manually select/deselect the tests depending on it.
+to skip them when installing without CUDA support. Additionally, the tests for sparse solver BaSpaCho are automatically 
+skipped when its extlib is not compiled.
 
 Tutorials
 ---------

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,3 @@ skip=theseus/__init__.py
 [tool:pytest]
 markers =
     cudaext: marks tests as requiring CUDA support
-    baspacho: marks tests as requiring BaSpaCho library

--- a/theseus/__init__.py
+++ b/theseus/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-__version__ = "0.1.1"
+__version__ = "0.1.2rc1"
 
 
 from .core import (  # usort: skip

--- a/theseus/constants.py
+++ b/theseus/constants.py
@@ -54,3 +54,21 @@ _SE3_NEAR_PI_EPS = EPSDict(float32_eps=1e-2, float64_eps=1e-7)
 _SE3_NEAR_ZERO_EPS = EPSDict(float32_eps=1e-2, float64_eps=5e-3)
 
 _SE3_HAT_EPS = EPSDict(float32_eps=5e-6, float64_eps=5e-7)
+
+_BASPACHO_NOT_INSTALLED_MSG = "Baspacho solver not in theseus extension library."
+
+
+def run_if_baspacho():
+    # Not sure what's a better place to put this in
+    import pytest
+
+    try:
+        import theseus.extlib.baspacho_solver  # noqa: F401
+
+        BASPACHO_EXT_NOT_AVAILABLE = False
+    except ModuleNotFoundError:
+        BASPACHO_EXT_NOT_AVAILABLE = True
+
+    return pytest.mark.skipif(
+        BASPACHO_EXT_NOT_AVAILABLE, reason=_BASPACHO_NOT_INSTALLED_MSG
+    )

--- a/theseus/extlib/tests/test_baspacho.py
+++ b/theseus/extlib/tests/test_baspacho.py
@@ -8,19 +8,9 @@ import pytest  # noqa: F401
 import torch  # needed for import of Torch C++ extensions to work
 from scipy.sparse import csr_matrix, tril
 
+
+from theseus.constants import run_if_baspacho
 from theseus.utils import random_sparse_binary_matrix, split_into_param_sizes
-
-try:
-    import theseus.extlib.baspacho_solver  # noqa: F401
-
-    BASPACHO_EXT_NOT_AVAILABLE = False
-except ModuleNotFoundError:
-    BASPACHO_EXT_NOT_AVAILABLE = True
-
-requires_baspacho = pytest.mark.skipif(
-    BASPACHO_EXT_NOT_AVAILABLE,
-    reason="Baspacho solver not in theseus extension library",
-)
 
 
 def check_baspacho(
@@ -116,9 +106,8 @@ def check_baspacho(
     assert all(np.linalg.norm(res) < 1e-10 for res in residuals)
 
 
-@requires_baspacho
-@pytest.mark.baspacho
-@pytest.mark.parametrize("batch_size", [8, 32])
+@run_if_baspacho()
+@pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.1, 1.7])
 @pytest.mark.parametrize("num_cols", [30, 70])
 @pytest.mark.parametrize("param_size_range", ["2:6", "1:13"])
@@ -134,10 +123,9 @@ def test_baspacho_cpu(batch_size, rows_to_cols_ratio, num_cols, param_size_range
     )
 
 
-@requires_baspacho
+@run_if_baspacho()
 @pytest.mark.cudaext
-@pytest.mark.baspacho
-@pytest.mark.parametrize("batch_size", [8, 32])
+@pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.1, 1.7])
 @pytest.mark.parametrize("num_cols", [30, 70])
 @pytest.mark.parametrize("param_size_range", ["2:6", "1:13"])

--- a/theseus/extlib/tests/test_baspacho_simple.py
+++ b/theseus/extlib/tests/test_baspacho_simple.py
@@ -8,17 +8,8 @@ import torch
 import numpy as np
 import pytest  # noqa: F401
 
-try:
-    import theseus.extlib.baspacho_solver  # noqa: F401
+from theseus.constants import run_if_baspacho
 
-    BASPACHO_EXT_NOT_AVAILABLE = False
-except ModuleNotFoundError:
-    BASPACHO_EXT_NOT_AVAILABLE = True
-
-requires_baspacho = pytest.mark.skipif(
-    BASPACHO_EXT_NOT_AVAILABLE,
-    reason="Baspacho solver not in theseus extension library",
-)
 
 # fmt: off
 mRowPtr = [ 0, 1, 3, 5, 8, 11, 13, 15, 17, 20, 23, 25, 27 ]
@@ -121,14 +112,11 @@ def check_simple(verbose=False, dev="cpu"):
     assert all(np.linalg.norm(res) < 1e-10 for res in residuals)
 
 
-@pytest.mark.baspacho
-@requires_baspacho
+@run_if_baspacho()
 def test_simple_cpu():
     check_simple(dev="cpu")
 
 
-@pytest.mark.cudaext
-@pytest.mark.baspacho
-@requires_baspacho
+@run_if_baspacho()
 def test_simple_cuda():
     check_simple(dev="cuda")

--- a/theseus/extlib/tests/test_baspacho_simple.py
+++ b/theseus/extlib/tests/test_baspacho_simple.py
@@ -117,6 +117,7 @@ def test_simple_cpu():
     check_simple(dev="cpu")
 
 
+@pytest.mark.cudaext
 @run_if_baspacho()
 def test_simple_cuda():
     check_simple(dev="cuda")

--- a/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
+++ b/theseus/optimizer/autograd/tests/test_baspacho_sparse_backward.py
@@ -9,21 +9,10 @@ import numpy as np
 from torch.autograd import gradcheck
 from theseus.optimizer.autograd import BaspachoSolveFunction
 
+from theseus.constants import run_if_baspacho
 from theseus.utils import random_sparse_binary_matrix, split_into_param_sizes
 
 import theseus as th
-
-try:
-    import theseus.extlib.baspacho_solver  # noqa: F401
-
-    BASPACHO_EXT_NOT_AVAILABLE = False
-except ModuleNotFoundError:
-    BASPACHO_EXT_NOT_AVAILABLE = True
-
-requires_baspacho = pytest.mark.skipif(
-    BASPACHO_EXT_NOT_AVAILABLE,
-    reason="Baspacho solver not in theseus extension library",
-)
 
 
 def check_sparse_backward_step(
@@ -81,8 +70,7 @@ def check_sparse_backward_step(
     assert gradcheck(BaspachoSolveFunction.apply, inputs, eps=1e-5, atol=1e-5)
 
 
-@requires_baspacho
-@pytest.mark.baspacho
+@run_if_baspacho()
 @pytest.mark.parametrize("batch_size", [2, 4])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.5])
 @pytest.mark.parametrize("num_cols", [15, 20])
@@ -101,9 +89,8 @@ def test_sparse_backward_step_cpu(
     )
 
 
-@requires_baspacho
+@run_if_baspacho()
 @pytest.mark.cudaext
-@pytest.mark.baspacho
 @pytest.mark.parametrize("batch_size", [2, 4])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.5])
 @pytest.mark.parametrize("num_cols", [15, 20])

--- a/theseus/optimizer/linear/tests/test_baspacho_sparse_solver.py
+++ b/theseus/optimizer/linear/tests/test_baspacho_sparse_solver.py
@@ -9,19 +9,8 @@ import numpy as np
 
 import theseus as th
 
+from theseus.constants import run_if_baspacho
 from theseus.utils import random_sparse_binary_matrix, split_into_param_sizes
-
-try:
-    import theseus.extlib.baspacho_solver  # noqa: F401
-
-    BASPACHO_EXT_NOT_AVAILABLE = False
-except ModuleNotFoundError:
-    BASPACHO_EXT_NOT_AVAILABLE = True
-
-requires_baspacho = pytest.mark.skipif(
-    BASPACHO_EXT_NOT_AVAILABLE,
-    reason="Baspacho solver not in theseus extension library",
-)
 
 
 def check_sparse_solver(
@@ -84,9 +73,8 @@ def check_sparse_solver(
         assert max_offset < 1e-4
 
 
-@requires_baspacho
-@pytest.mark.baspacho
-@pytest.mark.parametrize("batch_size", [8, 32])
+@run_if_baspacho()
+@pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.1, 1.7])
 @pytest.mark.parametrize("num_cols", [30, 70])
 @pytest.mark.parametrize("param_size_range", ["2:6", "1:13"])
@@ -104,10 +92,9 @@ def test_baspacho_solver_cpu(
     )
 
 
-@requires_baspacho
+@run_if_baspacho()
 @pytest.mark.cudaext
-@pytest.mark.baspacho
-@pytest.mark.parametrize("batch_size", [8, 32])
+@pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("rows_to_cols_ratio", [1.1, 1.7])
 @pytest.mark.parametrize("num_cols", [30, 70])
 @pytest.mark.parametrize("param_size_range", ["2:6", "1:13"])


### PR DESCRIPTION
Main changes:

* Changed build script so that it always does the equivalent of `THESEUS_FORCE_CUDA=1`. This argument no longer needs to be passed.
* Hardcoded CUDA archs in the build script for. I'm guessing this  might be controversial, but couldn't get this to compile otherwise.
* Fixed build script so that it works with CPU-only install.
* Removed pytest baspacho marker. I don't think it's needed because tests are skipped automatically if BaSpaCho is not found.
* Added clearer README instructions. 
* Added a preliminary version bump (0.1.2rc1) as the build script requires a tag to work properly. 