### PR TITLE
Small vectorization improvements

### DIFF
--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -509,9 +509,7 @@ class Objective:
         self._batch_size = _get_batch_size(batch_sizes)
 
     def _vectorization_needs_update(self):
-        num_updates = dict(
-            (name, v._num_updates) for name, v in self._all_variables.items()
-        )
+        num_updates = {name: v._num_updates for name, v in self._all_variables.items()}
         needs = False
         if num_updates != self._num_updates_variables:
             self._num_updates_variables = num_updates
@@ -575,6 +573,11 @@ class Objective:
         self._retract_method(
             delta, ordering, ignore_mask=ignore_mask, force_update=force_update
         )
+        # Updating immediately is useful, since it will keep grad history if
+        # needed. Otherwise, with lazy waitng we can be in a situation were
+        # vectorization is updated with torch.no_grad() (e.g., for error logging),
+        # and then it has to be run again later when grad is back on.
+        self.update_vectorization_if_needed()
 
     def _enable_vectorization(
         self,

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -574,7 +574,7 @@ class Objective:
             delta, ordering, ignore_mask=ignore_mask, force_update=force_update
         )
         # Updating immediately is useful, since it will keep grad history if
-        # needed. Otherwise, with lazy waitng we can be in a situation were
+        # needed. Otherwise, with lazy waitng we can be in a situation where
         # vectorization is updated with torch.no_grad() (e.g., for error logging),
         # and then it has to be run again later when grad is back on.
         self.update_vectorization_if_needed()

--- a/theseus/core/vectorizer.py
+++ b/theseus/core/vectorizer.py
@@ -228,7 +228,11 @@ class Vectorize:
                 # when updating the vectorized variable containers.
                 tensor = (
                     var.tensor
-                    if (var_batch_size > 1 or Vectorize._SHARED_TOKEN in name)
+                    if (
+                        var_batch_size > 1
+                        or objective_batch_size == 1
+                        or Vectorize._SHARED_TOKEN in name
+                    )
                     else Vectorize._expand(var.tensor, objective_batch_size)
                 )
                 names_to_tensors[name].append(tensor)


### PR DESCRIPTION
This PR commits two changes:

- Don't expand tensors in vectorization if the objective's batch size = 1
- Retract all variables now updates vectorization immediately, which avoids some cases were vectorization had to be run twice with the same data (because of torch.no_grad() uses). 

TODO: check if this changes times in the PGO benchmark. In a small BA script it looks like this leads to some improvements in running time (~10-20%). 