### PR TITLE
Add sparse solvers support to LM adaptive damping

### DIFF
--- a/examples/configs/pose_graph/pose_graph_synthetic.yaml
+++ b/examples/configs/pose_graph/pose_graph_synthetic.yaml
@@ -12,14 +12,16 @@ batch_size: 128
 
 
 inner_optim:
-  optimizer_cls: GaussNewton
+  optimizer_cls: LevenbergMarquardt
+  optimizer_kwargs:
+    backward_mode: implicit
+    verbose: true
+    track_err_history: true
+    __keep_final_step_size__: true
+    adaptive_damping: true
   solver: sparse
   max_iters: 10 
   step_size: 0.75
-  backward_mode: implicit
-  verbose: true
-  track_err_history: true
-  keep_step_size: true
   regularize: true
   ratio_known_poses: 0.1
   reg_w: 1e-3

--- a/examples/pose_graph/pose_graph_synthetic.py
+++ b/examples/pose_graph/pose_graph_synthetic.py
@@ -211,12 +211,7 @@ def run(
         pr.enable()
         theseus_outputs, _ = theseus_optim.forward(
             input_tensors=theseus_inputs,
-            optimizer_kwargs={
-                "verbose": cfg.inner_optim.verbose,
-                "track_err_history": cfg.inner_optim.track_err_history,
-                "backward_mode": cfg.inner_optim.backward_mode,
-                "__keep_final_step_size__": cfg.inner_optim.keep_step_size,
-            },
+            optimizer_kwargs={**cfg.inner_optim.optimizer_kwargs},
         )
         pr.disable()
         end_event.record()

--- a/tests/optimizer/linear/test_dense_solver.py
+++ b/tests/optimizer/linear/test_dense_solver.py
@@ -28,7 +28,11 @@ def test_dense_solvers(damp_as_tensor):
         solver = solver_cls(
             void_objective, linearization_kwargs={"ordering": void_ordering}
         )
-        solver.linearization.AtA, solver.linearization.Atb, x = _create_linear_system()
+        (
+            solver.linearization._AtA,
+            solver.linearization._Atb,
+            x,
+        ) = _create_linear_system()
         solved_x = solver.solve().squeeze()
         error = torch.norm(x - solved_x, p=float("inf"))
         assert error < 1e-4
@@ -88,8 +92,8 @@ def test_handle_singular():
                 check_singular=True,
             )
             (
-                solver.linearization.AtA,
-                solver.linearization.Atb,
+                solver.linearization._AtA,
+                solver.linearization._Atb,
                 x,
             ) = _create_linear_system(batch_size=batch_size, matrix_size=10)
             solver.linearization.AtA[:mid_point] = torch.zeros(matrix_size, matrix_size)

--- a/tests/optimizer/nonlinear/common.py
+++ b/tests/optimizer/nonlinear/common.py
@@ -223,10 +223,16 @@ def _check_optimizer_returns_fail_status_on_singular(
             pass
 
         def _linearize_hessian_impl(self):
-            self.AtA = torch.zeros(
+            self._AtA = torch.zeros(
                 self.objective.batch_size, self.num_rows, self.num_cols
             )
-            self.Atb = torch.ones(self.objective.batch_size, self.num_cols)
+            self._Atb = torch.ones(self.objective.batch_size, self.num_cols)
+
+        def _ata_impl(self) -> torch.Tensor:
+            return self._AtA
+
+        def _atb_impl(self) -> torch.Tensor:
+            return self._Atb
 
     class MockCostFunction(th.CostFunction):
         def __init__(self, optim_vars, cost_weight):

--- a/theseus/optimizer/autograd/baspacho_sparse_autograd.py
+++ b/theseus/optimizer/autograd/baspacho_sparse_autograd.py
@@ -6,69 +6,7 @@ from typing import Tuple, Optional
 import torch
 
 from ..linear_system import SparseStructure
-
-from scipy.sparse import csr_matrix, csc_matrix
-import numpy as np
-
-
-def mat_vec_cpu(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v):
-    assert batch_size == A_val.shape[0]
-    num_rows = len(A_rowPtr) - 1
-    retv_data = np.array(
-        [
-            csr_matrix((A_val[i].numpy(), A_colInd, A_rowPtr), (num_rows, num_cols))
-            * v[i]
-            for i in range(batch_size)
-        ],
-        dtype=np.float64,
-    )
-    return torch.tensor(retv_data, dtype=torch.float64)
-
-
-def tmat_vec_cpu(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v):
-    assert batch_size == A_val.shape[0]
-    num_rows = len(A_rowPtr) - 1
-    retv_data = np.array(
-        [
-            csc_matrix((A_val[i].numpy(), A_colInd, A_rowPtr), (num_cols, num_rows))
-            * v[i]
-            for i in range(batch_size)
-        ],
-        dtype=np.float64,
-    )
-    return torch.tensor(retv_data, dtype=torch.float64)
-
-
-def mat_vec(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v):
-    if A_rowPtr.device.type == "cuda":
-        try:
-            from theseus.extlib.mat_mult import mat_vec as mat_vec_cuda
-        except Exception as e:
-            raise RuntimeError(
-                "Theseus C++/Cuda extension cannot be loaded\n"
-                "even if Cuda appears to be available. Make sure Theseus\n"
-                "is installed with Cuda support (export CUDA_HOME=...)\n"
-                f"{type(e).__name__}: {e}"
-            )
-        return mat_vec_cuda(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v)
-    else:
-        return mat_vec_cpu(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v)
-
-
-def tmat_vec(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v):
-    if A_rowPtr.device.type == "cuda":
-        try:
-            from theseus.extlib.mat_mult import tmat_vec as tmat_vec_cuda
-        except Exception as e:
-            raise RuntimeError(
-                "Theseus C++/Cuda extension cannot be loaded\n"
-                "even if Cuda appears to be available. Make sure Theseus\n"
-                "is installed with Cuda support (export CUDA_HOME=...)\n"
-                f"{type(e).__name__}: {e}"
-            )
-        return tmat_vec_cuda(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v)
-    else:
-        return tmat_vec_cpu(batch_size, num_cols, A_rowPtr, A_colInd, A_val, v)
+from theseus.utils.sparse_matrix_utils import mat_vec, tmat_vec
 
 
 class BaspachoSolveFunction(torch.autograd.Function):

--- a/theseus/optimizer/dense_linearization.py
+++ b/theseus/optimizer/dense_linearization.py
@@ -22,9 +22,9 @@ class DenseLinearization(Linearization):
     ):
         super().__init__(objective, ordering)
         self.A: torch.Tensor = None
-        self.AtA: torch.Tensor = None
         self.b: torch.Tensor = None
-        self.Atb: torch.Tensor = None
+        self._AtA: torch.Tensor = None
+        self._Atb: torch.Tensor = None
 
     def _linearize_jacobian_impl(self):
         err_row_idx = 0
@@ -58,8 +58,14 @@ class DenseLinearization(Linearization):
     def _linearize_hessian_impl(self):
         self._linearize_jacobian_impl()
         At = self.A.transpose(1, 2)
-        self.AtA = At.bmm(self.A)
-        self.Atb = At.bmm(self.b.unsqueeze(2))
+        self._AtA = At.bmm(self.A)
+        self._Atb = At.bmm(self.b.unsqueeze(2))
 
     def hessian_approx(self):
-        return self.AtA
+        return self._AtA
+
+    def _ata_impl(self) -> torch.Tensor:
+        return self._AtA
+
+    def _atb_impl(self) -> torch.Tensor:
+        return self._Atb

--- a/theseus/optimizer/linearization.py
+++ b/theseus/optimizer/linearization.py
@@ -6,6 +6,8 @@
 import abc
 from typing import List, Optional
 
+import torch
+
 from theseus.core import Objective
 
 from .variable_ordering import VariableOrdering
@@ -17,7 +19,7 @@ class Linearization(abc.ABC):
         self,
         objective: Objective,
         ordering: Optional[VariableOrdering] = None,
-        **kwargs
+        **kwargs,
     ):
         self.objective = objective
         if ordering is None:
@@ -54,4 +56,22 @@ class Linearization(abc.ABC):
         self._linearize_hessian_impl()
 
     def hessian_approx(self):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"hessian_approx is not implemented for {self.__class__.__name__}"
+        )
+
+    @abc.abstractmethod
+    def _ata_impl(self) -> torch.Tensor:
+        pass
+
+    @abc.abstractmethod
+    def _atb_impl(self) -> torch.Tensor:
+        pass
+
+    @property
+    def AtA(self) -> torch.Tensor:
+        return self._ata_impl()
+
+    @property
+    def Atb(self) -> torch.Tensor:
+        return self._atb_impl()

--- a/theseus/optimizer/nonlinear/levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/levenberg_marquardt.py
@@ -2,13 +2,12 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import warnings
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 import torch
 
 from theseus.core import Objective
-from theseus.optimizer import DenseLinearization, Linearization
+from theseus.optimizer import Linearization
 from theseus.optimizer.linear import (
     BaspachoSparseSolver,
     CholeskyDenseSolver,
@@ -151,14 +150,6 @@ class LevenbergMarquardt(NonlinearLeastSquares):
         if not adaptive_damping:
             return
         linearization = self.linear_solver.linearization
-        if not isinstance(linearization, DenseLinearization):
-            warnings.warn(
-                "Adaptive damping is currently only supported with "
-                "DenseLinearization. Damping will not update.",
-                RuntimeWarning,
-            )
-            return
-
         damping = (
             self._damping.view(-1, 1)
             if isinstance(self._damping, torch.Tensor)

--- a/theseus/optimizer/sparse_linearization.py
+++ b/theseus/optimizer/sparse_linearization.py
@@ -150,6 +150,8 @@ class SparseLinearization(Linearization):
                 self.objective.device
             )
             A_colInd = A_rowPtr.new_tensor(self.A_col_ind)
+
+            # unsqueeze at the end for consistency with DenseLinearization
             self._Atb = tmat_vec(
                 self.objective.batch_size,
                 self.num_cols,
@@ -157,7 +159,5 @@ class SparseLinearization(Linearization):
                 A_colInd,
                 self.A_val,
                 self.b,
-            ).unsqueeze(
-                2
-            )  # for consistency with DenseLinearization
+            ).unsqueeze(2)
         return self._Atb

--- a/theseus/utils/__init__.py
+++ b/theseus/utils/__init__.py
@@ -3,5 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .sparse_matrix_utils import random_sparse_binary_matrix, split_into_param_sizes
+from .sparse_matrix_utils import (
+    tmat_vec,
+    mat_vec,
+    random_sparse_binary_matrix,
+    split_into_param_sizes,
+)
 from .utils import build_mlp, gather_from_rows_cols, numeric_jacobian


### PR DESCRIPTION
This PR adds a method to compute `Atb` in the sparse linearization, which we can use for the adaptive damping computation. 

I also sneaked in a change to the PGO example, to make it easier to pass optimizer kwargs. 