### PR TITLE
Minor vmap fix in SO2

### DIFF
--- a/theseus/geometry/so2.py
+++ b/theseus/geometry/so2.py
@@ -260,7 +260,7 @@ class SO2(LieGroup):
         else:
             point_tensor = point.tensor
         px, py = point_tensor[:, 0], point_tensor[:, 1]
-        new_point_tensor = point_tensor.new_empty(batch_size, 2)
+        new_point_tensor = cosine.new_empty(batch_size, 2)
         new_point_tensor[:, 0] = cosine * px - sine * py
         new_point_tensor[:, 1] = sine * px + cosine * py
         return Point2(tensor=new_point_tensor)

--- a/theseus/geometry/so2.py
+++ b/theseus/geometry/so2.py
@@ -249,7 +249,6 @@ class SO2(LieGroup):
         cosine: torch.Tensor,
         sine: torch.Tensor,
     ) -> Point2:
-        batch_size = max(point.shape[0], cosine.shape[0])
         if isinstance(point, torch.Tensor):
             if point.ndim != 2 or point.shape[1] != 2:
                 raise ValueError(
@@ -260,10 +259,11 @@ class SO2(LieGroup):
         else:
             point_tensor = point.tensor
         px, py = point_tensor[:, 0], point_tensor[:, 1]
-        new_point_tensor = cosine.new_empty(batch_size, 2)
-        new_point_tensor[:, 0] = cosine * px - sine * py
-        new_point_tensor[:, 1] = sine * px + cosine * py
-        return Point2(tensor=new_point_tensor)
+        return Point2(
+            tensor=torch.stack(
+                [cosine * px - sine * py, sine * px + cosine * py], dim=1
+            )
+        )
 
     def rotate(
         self,


### PR DESCRIPTION
Creating the new tensor from `cosine` is better, since our typical use case uses vmap over the optimization variable. The previous version could result in errors in AutodiffCostFunction in some corner cases (@rmurai0610 hit one of these). The caveat is that the new version will fail if we vmap over the points, but there is no easy workaround for this. From conversation with @zou3519 it seems that `functorch` team is working on some better API to lift tensors to their batched versions. 