### PR TITLE
Change Objective.error() so it can be vectorized w/o changing vectorized cache

### DIFF
--- a/tests/core/test_vectorizer.py
+++ b/tests/core/test_vectorizer.py
@@ -197,7 +197,7 @@ def test_vectorized_error():
         vectorization = th.Vectorize(objective)
         objective.update_vectorization_if_needed()
 
-        assert objective._cost_functions_iterable is vectorization._cost_fn_wrappers
+        assert objective._jacobians_iter is vectorization._cost_fn_wrappers
         _check_vectorized_wrappers(vectorization, objective)
 
         squared_error = torch.cat(

--- a/tests/core/test_vectorizer.py
+++ b/tests/core/test_vectorizer.py
@@ -197,7 +197,7 @@ def test_vectorized_error():
         vectorization = th.Vectorize(objective)
         objective.update_vectorization_if_needed()
 
-        assert objective._jacobians_iter is vectorization._cost_fn_wrappers
+        assert objective._vectorized_jacobians_iter is vectorization._cost_fn_wrappers
         _check_vectorized_wrappers(vectorization, objective)
 
         squared_error = torch.cat(

--- a/tests/core/test_vectorizer.py
+++ b/tests/core/test_vectorizer.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from unittest import mock
 
 import numpy as np
 import pytest  # noqa: F401
@@ -50,7 +51,7 @@ def test_costs_vars_and_err_before_vectorization():
         # Check that the vectorizer's cost functions have the right variables and error
         saw_cf1 = False
         saw_cf2 = False
-        for cf in objective._get_iterator():
+        for cf in objective._get_jacobians_iter():
             assert isinstance(cf, _CostFunctionWrapper)
             optim_vars = [v for v in cf.optim_vars]
             aux_vars = [v for v in cf.aux_vars]
@@ -150,6 +151,16 @@ def test_correct_schemas_and_shared_vars():
     assert seen_cnt == [1] * 7
 
 
+def _check_vectorized_wrappers(vectorization, objective):
+    for w in vectorization._cost_fn_wrappers:
+        for cost_fn in objective.cost_functions.values():
+            if cost_fn is w.cost_fn:
+                w_jac, w_err = cost_fn.weighted_jacobians_error()
+                assert w._cached_error.allclose(w_err)
+                for jac, exp_jac in zip(w._cached_jacobians, w_jac):
+                    torch.testing.assert_close(jac, exp_jac, atol=1e-6, rtol=1e-6)
+
+
 def test_vectorized_error():
     rng = np.random.default_rng(0)
     generator = torch.Generator()
@@ -159,11 +170,12 @@ def test_vectorized_error():
         objective = th.Objective()
         batch_size = rng.choice(range(1, 11))
 
+        n_vars = rng.choice([1, 10])
         vectors = [
             th.Vector(
                 tensor=torch.randn(batch_size, dim, generator=generator), name=f"v{i}"
             )
-            for i in range(rng.choice([1, 10]))
+            for i in range(n_vars)
         ]
         target = th.Vector(dim, name="target")
         w = th.ScaleCostWeight(torch.randn(1, generator=generator))
@@ -186,18 +198,36 @@ def test_vectorized_error():
         objective.update_vectorization_if_needed()
 
         assert objective._cost_functions_iterable is vectorization._cost_fn_wrappers
-        for w in vectorization._cost_fn_wrappers:
-            for cost_fn in objective.cost_functions.values():
-                if cost_fn is w.cost_fn:
-                    w_jac, w_err = cost_fn.weighted_jacobians_error()
-                    assert w._cached_error.allclose(w_err)
-                    for jac, exp_jac in zip(w._cached_jacobians, w_jac):
-                        assert jac.allclose(exp_jac, atol=1e-6)
+        _check_vectorized_wrappers(vectorization, objective)
 
         squared_error = torch.cat(
             [cf.weighted_error() for cf in objective.cost_functions.values()], dim=1
         )
-        assert squared_error.allclose(objective.error())
+        torch.testing.assert_close(squared_error, objective.error())
+
+        # Check that calling error(also_update=False) changes the result but doesn't
+        # change the vectorized wrappers
+        another_squared_error = objective.error(
+            {f"v{i}": torch.ones(batch_size, dim) for i in range(n_vars)},
+            also_update=False,
+        )
+        assert not another_squared_error.allclose(squared_error)
+        _check_vectorized_wrappers(vectorization, objective)
+
+        # Just to be sure, check that objective.error() is calling
+        # the vectorized error iterator.
+        called = [False]
+
+        def mock_err_iter(self):
+            called[0] = True
+            return self._cost_fn_wrappers  # just to have the same return type
+
+        with mock.patch.object(
+            th.Vectorize, "_get_vectorized_error_iter", mock_err_iter
+        ):
+            th.Vectorize(objective)
+            objective.error()
+            assert called[0]
 
 
 def test_vectorized_retract():

--- a/tests/test_theseus_layer.py
+++ b/tests/test_theseus_layer.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from unittest import mock
 
-import mock
 import pytest  # noqa: F401
 import torch
 import torch.nn as nn

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -623,6 +623,7 @@ class Objective:
         self._vectorization_run = None
         self._vectorization_to = None
         self._retract_method = Objective._retract_base
+        self._get_error_iter = Objective._get_error_iter_base
         self._vectorized = False
 
     @property
@@ -632,6 +633,7 @@ class Objective:
             == (self._jacobians_iter is None)
             == (self._vectorization_run is None)
             == (self._vectorization_to is None)
+            == (self._get_error_iter is Objective._get_error_iter_base)
             == (self._retract_method is Objective._retract_base)
         )
         return self._vectorized

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -72,7 +72,7 @@ class Objective:
         # computes these quantities on demand.
         # But when vectorization is on, it returns separate cost function
         # containers that serve cached jacobians and errors that have been
-        # previously by the vectorization computed.
+        # previously computed by the vectorization.
         self._jacobians_iter: Optional[Iterable[CostFunction]] = None
 
         # Used to vectorize cost functions error + jacobians after an update

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -405,6 +405,13 @@ class Objective:
                     old_tensors[var] = self.optim_vars[var].tensor
             self.update(input_tensors=input_tensors)
 
+        # Current behavior when vectorization is on, is to always compute the error.
+        # One could potentially optimize by only recompute when `input_tensors`` is
+        # not None, and serving from the jacobians cache. However, when robust cost
+        # functions are present this results in incorrect rescaling of error terms
+        # so we are currently avoiding this optimization. Optimizers also compute error
+        # by passing `input_tensors`, so for optimizers the current version should be
+        # good enough.
         error_vector = torch.cat(
             [cf.weighted_error() for cf in self._get_error_iter()], dim=1
         )

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -69,7 +69,9 @@ class Objective:
         # This gets replaced when cost function vectorization is used
         self._cost_functions_iterable: Optional[Iterable[CostFunction]] = None
 
-        # Used to vectorize cost functions after update
+        # Used to vectorize cost functions error + jacobians after an update
+        # The results are cached so that the `self._get_jacobians_iter()` returns
+        # them whenever called if no other updates have been done
         self._vectorization_run: Optional[Callable] = None
 
         # If vectorization is on, this will also handle vectorized containers
@@ -532,11 +534,11 @@ class Objective:
     def __iter__(self):
         return iter([cf for cf in self.cost_functions.values()])
 
-    def _get_iterator(self):
+    def _get_jacobians_iter(self) -> Iterable:
         self.update_vectorization_if_needed()
         if self._cost_functions_iterable is None:
-            return iter([cf for cf in self.cost_functions.values()])
-        return iter([cf for cf in self._cost_functions_iterable])
+            return iter(cf for cf in self.cost_functions.values())
+        return iter(cf for cf in self._cost_functions_iterable)
 
     # Applies to() with given args to all tensors in the objective
     def to(self, *args, **kwargs):

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -623,7 +623,7 @@ class Objective:
         self._vectorization_run = None
         self._vectorization_to = None
         self._retract_method = Objective._retract_base
-        self._get_error_iter = Objective._get_error_iter_base
+        self._get_error_iter = self._get_error_iter_base
         self._vectorized = False
 
     @property
@@ -633,7 +633,7 @@ class Objective:
             == (self._jacobians_iter is None)
             == (self._vectorization_run is None)
             == (self._vectorization_to is None)
-            == (self._get_error_iter is Objective._get_error_iter_base)
-            == (self._retract_method is Objective._retract_base)
+            == (self._get_error_iter == self._get_error_iter_base)
+            == (self._retract_method == Objective._retract_base)
         )
         return self._vectorized

--- a/theseus/core/vectorizer.py
+++ b/theseus/core/vectorizer.py
@@ -34,9 +34,15 @@ def _get_cost_function_schema(cost_function: CostFunction) -> _CostFunctionSchem
     )
 
 
+# Identifies what quantities vectorizaton computes for all cost functions
 class _VectorizationMode(Enum):
+    # Only computes cf.error()
     ERROR = 0
+    # Only computes cf.weighted_error()
     WEIGHTED_ERROR = 1
+    # Computes cf.weighted_jacobians_error()
+    # For this mode the results are stored in a persistent cache.
+    # For the other two modes, the results are stored in a temporary one.
     FULL = 2
 
 

--- a/theseus/core/vectorizer.py
+++ b/theseus/core/vectorizer.py
@@ -35,6 +35,12 @@ def _get_cost_function_schema(cost_function: CostFunction) -> _CostFunctionSchem
 
 
 # Identifies what quantities vectorizaton computes for all cost functions
+#
+# Currently we select it manually in two places:
+# 1.) when requesting to compute Objective.error() we select WEIGHTED_ERROR,
+# so that we compute the vectorized error w/o modifying the permanent caches.
+# 2.) when Objective requests that the vectorization is updated, then we use
+# FULL so that we compute jacobians and replace the permanent caches.
 class _VectorizationMode(Enum):
     # Only computes cf.error()
     ERROR = 0

--- a/theseus/core/vectorizer.py
+++ b/theseus/core/vectorizer.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
+from enum import Enum
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type
 
 import torch
@@ -31,6 +32,12 @@ def _get_cost_function_schema(cost_function: CostFunction) -> _CostFunctionSchem
         + (_fullname(cost_function.weight),)
         + tuple(_varinfo(v) for v in cost_function.weight.aux_vars)
     )
+
+
+class _VectorizationMode(Enum):
+    ERROR = 0
+    WEIGHTED_ERROR = 1
+    FULL = 2
 
 
 # This wrapper allows the weighted error and jacobians to be replaced by pre-computed
@@ -123,6 +130,7 @@ class Vectorize:
             self._vectorize,
             self._to,
             self._vectorized_retract_optim_vars,
+            self._get_vectorized_error_iter,
             self,
         )
 
@@ -269,6 +277,17 @@ class Vectorize:
                 var_tensor = torch.cat(all_var_tensors, dim=0)
             var.update(var_tensor)
 
+    @staticmethod
+    def _get_fn_results_for_mode(
+        mode: _VectorizationMode, cost_fn: CostFunction
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
+        if mode == _VectorizationMode.FULL:
+            return cost_fn.weighted_jacobians_error()
+        elif mode == _VectorizationMode.ERROR:
+            return None, cost_fn.error()
+        else:
+            return None, cost_fn.weighted_error()
+
     # Computes the error of the vectorized cost function and distributes the error
     # to the cost function wrappers. The list of wrappers must correspond to the
     # same schema from which the vectorized cost function was obtained.
@@ -277,15 +296,17 @@ class Vectorize:
         vectorized_cost_fn: CostFunction,
         cost_fn_wrappers: List[_CostFunctionWrapper],
         batch_size: int,
+        mode: _VectorizationMode,
     ):
-        v_jac, v_err = vectorized_cost_fn.weighted_jacobians_error()
+        v_jac, v_err = Vectorize._get_fn_results_for_mode(mode, vectorized_cost_fn)
         start_idx = 0
         for wrapper in cost_fn_wrappers:
             assert wrapper._cached_error is None
             assert wrapper._cached_jacobians is None
             v_slice = slice(start_idx, start_idx + batch_size)
             wrapper._cached_error = v_err[v_slice]
-            wrapper._cached_jacobians = [jac[v_slice] for jac in v_jac]
+            if v_jac is not None:
+                wrapper._cached_jacobians = [jac[v_slice] for jac in v_jac]
             start_idx += batch_size
 
     def _clear_wrapper_caches(self):
@@ -296,19 +317,24 @@ class Vectorize:
         if self._empty_cuda_cache:
             torch.cuda.empty_cache()
 
-    # This could be a static method, but writing like this makes some unit tests
-    # easier
+    # This could be a static method, but writing like this makes some unit tests easier
     def _handle_singleton_wrapper(
-        self, _: _CostFunctionSchema, cost_fn_wrappers: List[_CostFunctionWrapper]
+        self,
+        _: _CostFunctionSchema,
+        cost_fn_wrappers: List[_CostFunctionWrapper],
+        mode: _VectorizationMode,
     ):
         wrapper = cost_fn_wrappers[0]
         (
             wrapper._cached_jacobians,
             wrapper._cached_error,
-        ) = wrapper.cost_fn.weighted_jacobians_error()
+        ) = Vectorize._get_fn_results_for_mode(mode, wrapper.cost_fn)
 
     def _handle_schema_vectorization(
-        self, schema: _CostFunctionSchema, cost_fn_wrappers: List[_CostFunctionWrapper]
+        self,
+        schema: _CostFunctionSchema,
+        cost_fn_wrappers: List[_CostFunctionWrapper],
+        mode: _VectorizationMode,
     ):
         var_names = self._var_names[schema]
         vectorized_cost_fn = self._vectorized_cost_fns[schema]
@@ -328,16 +354,35 @@ class Vectorize:
             len(cost_fn_wrappers),
         )
         Vectorize._compute_error_and_replace_wrapper_caches(
-            vectorized_cost_fn, cost_fn_wrappers, batch_size
+            vectorized_cost_fn, cost_fn_wrappers, batch_size, mode
         )
 
-    def _vectorize(self):
-        self._clear_wrapper_caches()
-        for schema, cost_fn_wrappers in self._schema_dict.items():
+    def _vectorize(
+        self, mode: _VectorizationMode = _VectorizationMode.FULL
+    ) -> Iterable[_CostFunctionWrapper]:
+        if mode == _VectorizationMode.FULL:
+            # In full mode we compute error and jacobians and update the vectorizer's
+            # permanent cache.
+            self._clear_wrapper_caches()
+            schema_dict = self._schema_dict
+            ret = self._cost_fn_wrappers
+        else:
+            # If not full vectorization, just copy the containers so that we don't override the
+            # permanent cache. The results will be returned in these temp containers.
+            schema_dict = {
+                schema: [_CostFunctionWrapper(cf.cost_fn) for cf in cf_list]
+                for schema, cf_list in self._schema_dict.items()
+            }
+            ret = [cf for cf_list in schema_dict.values() for cf in cf_list]
+        for schema, cost_fn_wrappers in schema_dict.items():
             if len(cost_fn_wrappers) == 1:
-                self._handle_singleton_wrapper(schema, cost_fn_wrappers)
+                self._handle_singleton_wrapper(schema, cost_fn_wrappers, mode)
             else:
-                self._handle_schema_vectorization(schema, cost_fn_wrappers)
+                self._handle_schema_vectorization(schema, cost_fn_wrappers, mode)
+        return ret
+
+    def _get_vectorized_error_iter(self) -> Iterable[_CostFunctionWrapper]:
+        return self._vectorize(_VectorizationMode.WEIGHTED_ERROR)
 
     @staticmethod
     def _vectorized_retract_optim_vars(

--- a/theseus/optimizer/dense_linearization.py
+++ b/theseus/optimizer/dense_linearization.py
@@ -38,7 +38,7 @@ class DenseLinearization(Linearization):
             device=self.objective.device,
             dtype=self.objective.dtype,
         )
-        for cost_function in self.objective._get_iterator():
+        for cost_function in self.objective._get_jacobians_iter():
             jacobians, error = cost_function.weighted_jacobians_error()
             num_rows = cost_function.dim()
             for var_idx_in_cost_function, var_jacobian in enumerate(jacobians):

--- a/theseus/optimizer/sparse_linearization.py
+++ b/theseus/optimizer/sparse_linearization.py
@@ -38,7 +38,7 @@ class SparseLinearization(Linearization):
         cost_function_row_block_starts = []  # where data start for this row block
         cost_function_stride = []  # total jacobian cols
 
-        for _, cost_function in enumerate(self.objective._get_iterator()):
+        for _, cost_function in enumerate(self.objective._get_jacobians_iter()):
             num_rows = cost_function.dim()
             col_slices_indices = []
             for var_idx_in_cost_function, variable in enumerate(
@@ -101,7 +101,7 @@ class SparseLinearization(Linearization):
         )
 
         err_row_idx = 0
-        for f_idx, cost_function in enumerate(self.objective._get_iterator()):
+        for f_idx, cost_function in enumerate(self.objective._get_jacobians_iter()):
             jacobians, error = cost_function.weighted_jacobians_error()
             num_rows = cost_function.dim()
             row_slice = slice(err_row_idx, err_row_idx + num_rows)


### PR DESCRIPTION
This will be useful for improving the accept/reject step of LM, and for more complex line search later. 

Closes #231. 

Note that as a consequence of this, this PR changes PGO optimization numerical results because now Objective.error() returns the non-scaled weighted error for `RobustCostFunction`, while the previous version was returning the scaled one. 