### PR TITLE
Add proper accept/reject logic for LM optimizer

### DIFF
--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -594,7 +594,13 @@ class Objective:
                 var.update(new_var.tensor, batch_ignore_mask=ignore_mask)
             var_idx += var.dof()
 
-    def retract_optim_vars(
+    # Retracts an ordered sequence of variables according to the
+    # corresponding `delta` tangent vectors.
+    # This function assumes that delta is constructed as follows:
+    #    For ordering = [v1 v2 ... vn]
+    #    delta = torch.cat([delta_v1, delta_v2, ..., delta_vn], dim=-1)
+    # where delta_vi.shape = (batch_size, vi.dof)
+    def retract_vars_sequence(
         self,
         delta: torch.Tensor,
         ordering: Iterable[Manifold],

--- a/theseus/optimizer/linear/linear_optimizer.py
+++ b/theseus/optimizer/linear/linear_optimizer.py
@@ -70,7 +70,7 @@ class LinearOptimizer(Optimizer):
                 warnings.warn(msg, RuntimeWarning)
                 info.status[:] = LinearOptimizerStatus.FAIL
                 return info
-        self.objective.retract_optim_vars(
+        self.objective.retract_vars_sequence(
             delta, self.linear_solver.linearization.ordering
         )
         info.status[:] = LinearOptimizerStatus.CONVERGED

--- a/theseus/optimizer/nonlinear/gauss_newton.py
+++ b/theseus/optimizer/nonlinear/gauss_newton.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Dict, Optional, Type
 
 import torch
 
@@ -27,7 +27,7 @@ class GaussNewton(NonlinearLeastSquares):
         rel_err_tolerance: float = 1e-8,
         max_iterations: int = 20,
         step_size: float = 1.0,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             objective,
@@ -40,26 +40,8 @@ class GaussNewton(NonlinearLeastSquares):
             rel_err_tolerance=rel_err_tolerance,
             max_iterations=max_iterations,
             step_size=step_size,
-            **kwargs
+            **kwargs,
         )
 
     def compute_delta(self, **kwargs) -> torch.Tensor:
         return self.linear_solver.solve()
-
-    def _step_impl(
-        self,
-        delta: torch.Tensor,
-        steps: torch.Tensor,
-        converged_indices: torch.Tensor,
-        force_update: bool,
-    ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        self.objective.retract_vars_sequence(
-            delta * steps,
-            self._tmp_optim_vars,
-            ignore_mask=converged_indices,
-            force_update=force_update,
-        )
-        tensor_map = {v.name: v.tensor for v in self._tmp_optim_vars}
-        with torch.no_grad():
-            error = self.objective.error_squared_norm(tensor_map, also_update=False)
-        return tensor_map, error

--- a/theseus/optimizer/nonlinear/gauss_newton.py
+++ b/theseus/optimizer/nonlinear/gauss_newton.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Tuple, Type
 
 import torch
 
@@ -45,3 +45,21 @@ class GaussNewton(NonlinearLeastSquares):
 
     def compute_delta(self, **kwargs) -> torch.Tensor:
         return self.linear_solver.solve()
+
+    def _step_impl(
+        self,
+        delta: torch.Tensor,
+        steps: torch.Tensor,
+        converged_indices: torch.Tensor,
+        force_update: bool,
+    ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
+        self.objective.retract_optim_vars(
+            delta * steps,
+            self._tmp_optim_vars,
+            ignore_mask=converged_indices,
+            force_update=force_update,
+        )
+        tensor_map = {v.name: v.tensor for v in self._tmp_optim_vars}
+        with torch.no_grad():
+            error = self.objective.error_squared_norm(tensor_map, also_update=False)
+        return tensor_map, error

--- a/theseus/optimizer/nonlinear/gauss_newton.py
+++ b/theseus/optimizer/nonlinear/gauss_newton.py
@@ -53,7 +53,7 @@ class GaussNewton(NonlinearLeastSquares):
         converged_indices: torch.Tensor,
         force_update: bool,
     ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        self.objective.retract_optim_vars(
+        self.objective.retract_vars_sequence(
             delta * steps,
             self._tmp_optim_vars,
             ignore_mask=converged_indices,

--- a/theseus/optimizer/nonlinear/levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/levenberg_marquardt.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 import torch
 
@@ -133,55 +133,62 @@ class LevenbergMarquardt(NonlinearLeastSquares):
             damping_eps=damping_eps,
         )
 
-    def _step_impl(
+    def _complete_step(
         self,
         delta: torch.Tensor,
-        steps: torch.Tensor,
-        converged_indices: torch.Tensor,
-        force_update: bool,
-    ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        self.objective.retract_vars_sequence(
-            delta * steps,
-            self._tmp_optim_vars,
-            ignore_mask=converged_indices,
-            force_update=force_update,
-        )
-        tensor_map = {v.name: v.tensor for v in self._tmp_optim_vars}
-        with torch.no_grad():
-            error = self.objective.error_squared_norm(tensor_map, also_update=False)
-        return tensor_map, error
-
-    # Updates damping per batch element depending on whether the last step
-    # was successful in decreasing error or not.
-    # Based on https://people.duke.edu/~hpgavin/ce281/lm.pdf, Section 4.1
-    # We currently use method (1) from 4.1.1
-    def _update_state_impl(
-        self,
-        last_err: torch.Tensor,
         new_err: torch.Tensor,
-        delta: torch.Tensor,
+        previous_err: torch.Tensor,
         adaptive_damping: bool = False,
         down_damping_ratio: float = 9.0,
         up_damping_ratio: float = 11.0,
         damping_accept: float = 0.1,
         **kwargs,
-    ) -> None:
-        if not adaptive_damping:
-            return
+    ) -> Optional[torch.Tensor]:
+        if adaptive_damping:
+            return self._check_accept(
+                delta,
+                new_err,
+                previous_err,
+                damping_accept,
+                down_damping_ratio,
+                up_damping_ratio,
+            )
+        else:
+            return None
+
+    # Checks if the step should be accepted (per batch element)
+    # Adjusts self._damping accordingly
+    # Returns a mask indicating which batch indices were accepted
+    #
+    # Based on https://people.duke.edu/~hpgavin/ce281/lm.pdf, Section 4.1
+    # We currently use method (1) from 4.1.1
+    @torch.no_grad()
+    def _check_accept(
+        self,
+        delta: torch.Tensor,
+        err: torch.Tensor,
+        previous_err: torch.Tensor,
+        damping_accept: float,
+        down_damping_ratio: float,
+        up_damping_ratio: float,
+    ) -> torch.Tensor:
         linearization = self.linear_solver.linearization
         damping = (
             self._damping.view(-1, 1)
             if isinstance(self._damping, torch.Tensor)
             else self._damping
         )
+        # Deliberately using Atb before updating the variables, according to
+        # the LM reference above
         den = (delta * (damping * delta + linearization.Atb.squeeze(2))).sum(dim=1)
-        rho = (last_err - new_err) / den
-        good_idx = rho > damping_accept
+        rho = (previous_err - err) / den
+        reject_indices = rho <= damping_accept
         self._damping = torch.where(
-            good_idx,
-            self._damping / down_damping_ratio,
+            reject_indices,
             self._damping * up_damping_ratio,
+            self._damping / down_damping_ratio,
         )
         self._damping = self._damping.clamp(
             LevenbergMarquardt._MIN_DAMPING, LevenbergMarquardt._MAX_DAMPING
         )
+        return reject_indices

--- a/theseus/optimizer/nonlinear/levenberg_marquardt.py
+++ b/theseus/optimizer/nonlinear/levenberg_marquardt.py
@@ -140,7 +140,7 @@ class LevenbergMarquardt(NonlinearLeastSquares):
         converged_indices: torch.Tensor,
         force_update: bool,
     ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        self.objective.retract_optim_vars(
+        self.objective.retract_vars_sequence(
             delta * steps,
             self._tmp_optim_vars,
             ignore_mask=converged_indices,

--- a/theseus/optimizer/nonlinear/nonlinear_optimizer.py
+++ b/theseus/optimizer/nonlinear/nonlinear_optimizer.py
@@ -8,7 +8,7 @@ import math
 import warnings
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, NoReturn, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, NoReturn, Optional, Type, Union
 
 import numpy as np
 import torch
@@ -333,15 +333,20 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
             with torch.no_grad():
                 if steps_tensor is None:
                     steps_tensor = torch.ones_like(delta) * self.params.step_size
-            # err is shape (batch_size,)
-            err = self.step(delta, steps_tensor, converged_indices, force_update)
+
+            # For now, step size is combined with delta. If we add more sophisticated
+            # line search, will probably need to pass it separately, or compute inside.
+            err = self.step(
+                delta * steps_tensor,
+                info.last_err,
+                converged_indices,
+                force_update,
+                **kwargs,
+            )  # err is shape (batch_size,)
 
             # check for convergence
             with torch.no_grad():
                 self._update_info(info, it_, err, converged_indices)
-                self.update_optimizer_state(
-                    last_err=info.last_err, new_err=err, delta=delta, **kwargs
-                )
                 if verbose:
                     print(
                         f"Nonlinear optimizer. Iteration: {it_+1}. "
@@ -461,20 +466,6 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     def compute_delta(self, **kwargs) -> torch.Tensor:
         pass
 
-    # Implements step for each individual optimizer subclass.
-    # Returns a dictionary of variable names to torch tensors,
-    # and tensor with the error after the update. The tensor
-    # must be detached from the compute graph.
-    @abc.abstractmethod
-    def _step_impl(
-        self,
-        delta: torch.Tensor,
-        steps: torch.Tensor,
-        converged_indices: torch.Tensor,
-        force_update: bool,
-    ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
-        pass
-
     # Given descent directions and step sizes, updates the optimization
     # variables.
     # Batch indices indicated by `converged_indices` mask are ignored
@@ -483,18 +474,28 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     def step(
         self,
         delta: torch.Tensor,
-        steps: torch.Tensor,
+        previous_err: torch.Tensor,
         converged_indices: torch.Tensor,
         force_update: bool,
+        **kwargs,
     ) -> torch.Tensor:
         # makes sure tmp cotainers are up to date with current variables
         self._update_tmp_optim_vars()
-        tensor_map, error = self._step_impl(
-            delta, steps, converged_indices, force_update
+        # stores the result of the retract step in `self._tmp_optim_vars`
+        self.objective.retract_vars_sequence(
+            delta,
+            self._tmp_optim_vars,
+            ignore_mask=converged_indices,
+            force_update=force_update,
         )
-        assert error.grad_fn is None
-        self.objective.update(tensor_map)
-        return error
+        tensor_map = {v.name: v.tensor for v in self._tmp_optim_vars}
+        with torch.no_grad():
+            err = self.objective.error_squared_norm(tensor_map, also_update=False)
+
+        reject_indices = self._complete_step(delta, err, previous_err, **kwargs)
+        self.objective.update(tensor_map, batch_ignore_mask=reject_indices)
+
+        return err
 
     # Resets any internal state needed by the optimizer for a new optimization
     # problem. Optimizer loop will pass all optimizer kwargs to this method.
@@ -502,24 +503,18 @@ class NonlinearOptimizer(Optimizer, abc.ABC):
     def reset(self, **kwargs) -> None:
         pass
 
-    # Called at the end of every optimizer step to update any internal state
-    # of the optimizer
-    @torch.no_grad()
-    def update_optimizer_state(
+    # Called at the end of step() but before variables are update to their new values.
+    # This method can be used to update any internal state of the optimizer and
+    # also obtain an optional tensor of shape (batch_size,), representing
+    # a mask of booleans indicating if the step is to be rejected for any
+    # batch elements.
+    #
+    # Deliberately not abstract, since some optimizers might not need this.
+    def _complete_step(
         self,
-        last_err: torch.Tensor,
-        new_err: torch.Tensor,
         delta: torch.Tensor,
-        **kwargs,
-    ) -> None:
-        self._update_state_impl(last_err, new_err, delta, **kwargs)
-
-    # Deliberately not abstract, since some optimizers might not need this
-    def _update_state_impl(
-        self,
-        last_err: torch.Tensor,
         new_err: torch.Tensor,
-        delta: torch.Tensor,
+        previous_err: torch.Tensor,
         **kwargs,
-    ) -> None:
-        pass
+    ) -> Optional[torch.Tensor]:
+        return None

--- a/theseus/theseus_layer.py
+++ b/theseus/theseus_layer.py
@@ -221,8 +221,8 @@ class TheseusLayerDLMForward(torch.autograd.Function):
         optim_tensors = saved_tensors[n + k + k :]
         grad_outputs = grad_outputs[:-1]
 
-        bwd_objective = ctx.bwd_objective
-        bwd_optimizer = ctx.bwd_optimizer
+        bwd_objective: Objective = ctx.bwd_objective
+        bwd_optimizer: Optimizer = ctx.bwd_optimizer
         epsilon = ctx.epsilon
         input_keys = ctx.input_keys
 
@@ -246,7 +246,7 @@ class TheseusLayerDLMForward(torch.autograd.Function):
         with torch.no_grad():
             bwd_optimizer.linear_solver.linearization.linearize()
             delta = bwd_optimizer.linear_solver.solve()
-            bwd_optimizer.objective.retract_optim_vars(
+            bwd_optimizer.objective.retract_vars_sequence(
                 delta, bwd_optimizer.linear_solver.linearization.ordering
             )
 


### PR DESCRIPTION
The previous version would adjust the damping depending on whether the step should be accepted or not, but it would nevertheless always take the step. This could result in divergence if the down damping ratio was too aggressive. 

In the new version, if the step should be rejected, it's indeed rejected (and this is computed independently for each batch element). 