### PR TITLE
Allow float data to be used with our sparse solver extensions

### DIFF
--- a/tests/optimizer/autograd/common.py
+++ b/tests/optimizer/autograd/common.py
@@ -13,9 +13,18 @@ def check_grad(solve_func, inputs, eps, atol, rtol):
     A_float = A_val.float()
     b_float = b.float()
     inputs2 = (A_float, b_float) + inputs[2:]
-    print(type(inputs2), len(inputs2))
     out_float = solve_func(*inputs2).sum()
     gA_float, gb_float = grad(out_float, (A_float, b_float))
 
+    # This mostly checks that backward() is not accumulating
+    # additional floating point errors on top of those expected by
+    # converting the input from double to float. Naive float casting
+    # in the backward python ops can result in differences in order of magnitude
+    # even for well-conditioned systems. These checks cover that case.
+    #
+    # Do note that, in general, it's possible to construct very
+    # ill-conditioned systems where the initial loss or precision is enough
+    # to get large gradient errors no matter what we do. This checks
+    # are not meant to capture such scenarios.
     torch.testing.assert_close(gA, gA_float.double(), rtol=rtol, atol=atol)
     torch.testing.assert_close(gb, gb_float.double(), rtol=rtol, atol=atol)

--- a/tests/optimizer/autograd/common.py
+++ b/tests/optimizer/autograd/common.py
@@ -1,0 +1,21 @@
+import torch
+from torch.autograd import grad, gradcheck
+
+
+def check_grad(solve_func, inputs, eps, atol, rtol):
+    assert gradcheck(solve_func, inputs, eps=eps, atol=atol)
+
+    A_val, b = inputs[0], inputs[1]
+    # Check that the gradient works correctly for floating point data
+    out = solve_func(*inputs).sum()
+    gA, gb = grad(out, (A_val, b))
+
+    A_float = A_val.float()
+    b_float = b.float()
+    inputs2 = (A_float, b_float) + inputs[2:]
+    print(type(inputs2), len(inputs2))
+    out_float = solve_func(*inputs2).sum()
+    gA_float, gb_float = grad(out_float, (A_float, b_float))
+
+    torch.testing.assert_close(gA, gA_float.double(), rtol=rtol, atol=atol)
+    torch.testing.assert_close(gb, gb_float.double(), rtol=rtol, atol=atol)

--- a/tests/optimizer/autograd/test_baspacho_sparse_backward.py
+++ b/tests/optimizer/autograd/test_baspacho_sparse_backward.py
@@ -6,13 +6,13 @@
 import pytest  # noqa: F401
 import torch
 import numpy as np
-from torch.autograd import gradcheck
 from theseus.optimizer.autograd import BaspachoSolveFunction
 
 from tests.extlib.common import run_if_baspacho
 from theseus.utils import random_sparse_binary_matrix, split_into_param_sizes
 
 import theseus as th
+from .common import check_grad
 
 
 def get_linearization_and_solver_for_random_sparse(
@@ -86,8 +86,7 @@ def check_sparse_backward_step(
         solver.symbolic_decomposition,
         damping_alpha_beta,
     )
-
-    assert gradcheck(BaspachoSolveFunction.apply, inputs, eps=1e-5, atol=1e-5)
+    check_grad(BaspachoSolveFunction.apply, inputs, eps=1e-5, atol=1e-5, rtol=1e-4)
 
 
 @run_if_baspacho()

--- a/tests/optimizer/autograd/test_lu_cuda_sparse_backward.py
+++ b/tests/optimizer/autograd/test_lu_cuda_sparse_backward.py
@@ -5,9 +5,9 @@
 
 import pytest  # noqa: F401
 import torch
-from torch.autograd import gradcheck
 
 import theseus as th
+from .common import check_grad
 
 
 def _build_sparse_mat(batch_size):
@@ -68,4 +68,4 @@ def test_sparse_backward_step():
         False,  # it's the same matrix, so no overwrite problems
     )
 
-    assert gradcheck(LUCudaSolveFunction.apply, inputs, eps=3e-4, atol=1e-3)
+    check_grad(LUCudaSolveFunction.apply, inputs, eps=3e-4, atol=1e-3, rtol=1e-4)

--- a/theseus/optimizer/autograd/baspacho_sparse_autograd.py
+++ b/theseus/optimizer/autograd/baspacho_sparse_autograd.py
@@ -34,27 +34,30 @@ class BaspachoSolveFunction(torch.autograd.Function):
         numeric_decomposition = symbolic_decomposition.create_numeric_decomposition(
             batch_size
         )
-        numeric_decomposition.add_MtM(A_val, A_row_ptr, A_col_ind)
+        A_val_double = A_val.double()
+        numeric_decomposition.add_MtM(A_val_double, A_row_ptr, A_col_ind)
         if damping_alpha_beta is not None:
-            numeric_decomposition.damp(*damping_alpha_beta)
+            numeric_decomposition.damp(
+                damping_alpha_beta[0].double(), damping_alpha_beta[1].double()
+            )
         numeric_decomposition.factor()
 
-        A_args = sparse_structure.num_cols, A_row_ptr, A_col_ind, A_val
-        Atb = tmat_vec(batch_size, *A_args, b)
+        A_args = sparse_structure.num_cols, A_row_ptr, A_col_ind, A_val_double
+        Atb = tmat_vec(batch_size, *A_args, b.double())
 
         x = Atb.clone()
         numeric_decomposition.solve(x)  # solve in place
 
         ctx.b = b
         ctx.x = x
-        ctx.A_val = A_val
+        ctx.A_val_double = A_val_double
         ctx.A_row_ptr = A_row_ptr
         ctx.A_col_ind = A_col_ind
         ctx.sparse_structure = sparse_structure
         ctx.numeric_decomposition = numeric_decomposition
         ctx.damping_alpha_beta = damping_alpha_beta
 
-        return x
+        return x.to(A_val.dtype)
 
     # Let v row vector, and w column vector of dimension n, m, and
     # A an nxm matrix. Then
@@ -112,10 +115,16 @@ class BaspachoSolveFunction(torch.autograd.Function):
         batch_size = grad_output.shape[0]
 
         H = grad_output.clone()
-        ctx.numeric_decomposition.solve(H)  # solve in place
+        H_double = H.double()
+        ctx.numeric_decomposition.solve(H_double)  # solve in place
 
-        A_args = ctx.sparse_structure.num_cols, ctx.A_row_ptr, ctx.A_col_ind, ctx.A_val
-        AH = mat_vec(batch_size, *A_args, H)
+        A_args = (
+            ctx.sparse_structure.num_cols,
+            ctx.A_row_ptr,
+            ctx.A_col_ind,
+            ctx.A_val_double,
+        )
+        AH = mat_vec(batch_size, *A_args, H_double)
         b_Ax = ctx.b - mat_vec(batch_size, *A_args, ctx.x)
 
         # now we fill values of a matrix with structure identical to A with
@@ -130,12 +139,13 @@ class BaspachoSolveFunction(torch.autograd.Function):
             dtype=grad_output.dtype,
             device=grad_output.device,
         )  # return value, A's grad
+        x = ctx.x.to(grad_output.dtype)
         for r in range(len(A_row_ptr) - 1):
             start, end = A_row_ptr[r], A_row_ptr[r + 1]
             columns = A_col_ind[start:end]  # col indices, for this row
             A_grad[:, start:end] = (
                 b_Ax[:, r].unsqueeze(1) * H[:, columns]
-                - AH[:, r].unsqueeze(1) * ctx.x[:, columns]
+                - AH[:, r].unsqueeze(1) * x[:, columns]
             )
 
         # apply correction if there is a multiplicative damping
@@ -144,7 +154,10 @@ class BaspachoSolveFunction(torch.autograd.Function):
             and (ctx.damping_alpha_beta[0] > 0.0).any()
         ):
             alpha = ctx.damping_alpha_beta[0].view(-1, 1)
-            alpha2Hx = (alpha * 2.0) * H * ctx.x  # componentwise product
-            A_grad -= ctx.A_val * alpha2Hx[:, ctx.A_col_ind.type(torch.long)]
+            alpha2Hx = (alpha * 2.0) * H * x  # componentwise product
+            A_grad -= (
+                ctx.A_val_double.to(grad_output.dtype)
+                * alpha2Hx[:, ctx.A_col_ind.type(torch.long)]
+            )
 
         return A_grad, AH, None, None, None, None, None, None

--- a/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
+++ b/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
@@ -46,22 +46,23 @@ class LUCudaSolveFunction(torch.autograd.Function):
 
         batch_size = A_val.shape[0]
 
+        A_val_double = A_val.double()
         AtA = mult_MtM(
-            batch_size, A_row_ptr, A_col_ind, A_val, AtA_row_ptr, AtA_col_ind
+            batch_size, A_row_ptr, A_col_ind, A_val_double, AtA_row_ptr, AtA_col_ind
         )
         if damping_alpha_beta is not None:
             AtA_args = sparse_structure.num_cols, AtA_row_ptr, AtA_col_ind, AtA
             apply_damping(batch_size, *AtA_args, *damping_alpha_beta)
         solver_context.factor(AtA)
 
-        A_args = sparse_structure.num_cols, A_row_ptr, A_col_ind, A_val
-        Atb = tmat_vec(batch_size, *A_args, b)
+        A_args = sparse_structure.num_cols, A_row_ptr, A_col_ind, A_val_double
+        Atb = tmat_vec(batch_size, *A_args, b.double())
         x = Atb.clone()
         solver_context.solve(x)  # solve in place
 
         ctx.b = b
         ctx.x = x
-        ctx.A_val = A_val
+        ctx.A_val_double = A_val_double
         ctx.A_row_ptr = A_row_ptr
         ctx.A_col_ind = A_col_ind
         ctx.sparse_structure = sparse_structure
@@ -71,7 +72,7 @@ class LUCudaSolveFunction(torch.autograd.Function):
         # HACK: allows to check if the context has been reused (and overwritten)
         ctx.factor_id = solver_context.factor_id if check_factor_id else None
 
-        return x
+        return x.to(A_val.dtype)
 
     # Let v row vector, and w column vector of dimension n, m, and
     # A an nxm matrix. Then
@@ -149,10 +150,16 @@ class LUCudaSolveFunction(torch.autograd.Function):
         batch_size = grad_output.shape[0]
 
         H = grad_output.clone()
-        ctx.solver_context.solve(H)  # solve in place
+        H_double = H.double()
+        ctx.solver_context.solve(H_double)  # solve in place
 
-        A_args = ctx.sparse_structure.num_cols, ctx.A_row_ptr, ctx.A_col_ind, ctx.A_val
-        AH = mat_vec(batch_size, *A_args, H)
+        A_args = (
+            ctx.sparse_structure.num_cols,
+            ctx.A_row_ptr,
+            ctx.A_col_ind,
+            ctx.A_val_double,
+        )
+        AH = mat_vec(batch_size, *A_args, H_double)
         b_Ax = ctx.b - mat_vec(batch_size, *A_args, ctx.x)
 
         # now we fill values of a matrix with structure identical to A with
@@ -165,12 +172,13 @@ class LUCudaSolveFunction(torch.autograd.Function):
         A_grad = torch.empty(
             size=(batch_size, len(A_col_ind)), dtype=grad_output.dtype, device="cuda"
         )  # return value, A's grad
+        x = ctx.x.to(grad_output.dtype)
         for r in range(len(A_row_ptr) - 1):
             start, end = A_row_ptr[r], A_row_ptr[r + 1]
             columns = A_col_ind[start:end]  # col indices, for this row
             A_grad[:, start:end] = (
                 b_Ax[:, r].unsqueeze(1) * H[:, columns]
-                - AH[:, r].unsqueeze(1) * ctx.x[:, columns]
+                - AH[:, r].unsqueeze(1) * x[:, columns]
             )
 
         # apply correction if there is a multiplicative damping
@@ -179,7 +187,10 @@ class LUCudaSolveFunction(torch.autograd.Function):
             and (ctx.damping_alpha_beta[0] > 0.0).any()
         ):
             alpha = ctx.damping_alpha_beta[0].view(-1, 1)
-            alpha2Hx = (alpha * 2.0) * H * ctx.x  # componentwise product
-            A_grad -= ctx.A_val * alpha2Hx[:, ctx.A_col_ind.type(torch.long)]
+            alpha2Hx = (alpha * 2.0) * H * x  # componentwise product
+            A_grad -= (
+                ctx.A_val_double.to(grad_output.dtype)
+                * alpha2Hx[:, ctx.A_col_ind.type(torch.long)]
+            )
 
         return A_grad, AH, None, None, None, None, None, None

--- a/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
+++ b/theseus/optimizer/autograd/lu_cuda_sparse_autograd.py
@@ -170,15 +170,14 @@ class LUCudaSolveFunction(torch.autograd.Function):
         A_row_ptr = ctx.sparse_structure.row_ptr
         batch_size = grad_output.shape[0]
         A_grad = torch.empty(
-            size=(batch_size, len(A_col_ind)), dtype=grad_output.dtype, device="cuda"
+            size=(batch_size, len(A_col_ind)), dtype=torch.double, device="cuda"
         )  # return value, A's grad
-        x = ctx.x.to(grad_output.dtype)
         for r in range(len(A_row_ptr) - 1):
             start, end = A_row_ptr[r], A_row_ptr[r + 1]
             columns = A_col_ind[start:end]  # col indices, for this row
             A_grad[:, start:end] = (
-                b_Ax[:, r].unsqueeze(1) * H[:, columns]
-                - AH[:, r].unsqueeze(1) * x[:, columns]
+                b_Ax[:, r].unsqueeze(1) * H_double[:, columns]
+                - AH[:, r].unsqueeze(1) * ctx.x[:, columns]
             )
 
         # apply correction if there is a multiplicative damping
@@ -187,10 +186,19 @@ class LUCudaSolveFunction(torch.autograd.Function):
             and (ctx.damping_alpha_beta[0] > 0.0).any()
         ):
             alpha = ctx.damping_alpha_beta[0].view(-1, 1)
-            alpha2Hx = (alpha * 2.0) * H * x  # componentwise product
+            alpha2Hx = (alpha * 2.0) * H_double * ctx.x  # componentwise product
             A_grad -= (
                 ctx.A_val_double.to(grad_output.dtype)
                 * alpha2Hx[:, ctx.A_col_ind.type(torch.long)]
             )
 
-        return A_grad, AH, None, None, None, None, None, None
+        return (
+            A_grad.to(dtype=grad_output.dtype),
+            AH.to(dtype=grad_output.dtype),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )

--- a/theseus/optimizer/sparse_linearization.py
+++ b/theseus/optimizer/sparse_linearization.py
@@ -157,7 +157,7 @@ class SparseLinearization(Linearization):
                 self.num_cols,
                 A_row_ptr,
                 A_col_ind,
-                self.A_val,
-                self.b,
+                self.A_val.double(),
+                self.b.double(),
             ).unsqueeze(2)
-        return self._Atb
+        return self._Atb.to(dtype=self.A_val.dtype)


### PR DESCRIPTION
Note that this doesn't changed the extensions themselves. We convert from float to double and back before calling the C++ routines. 

PS: I had to make the same change in the two different solvers, so I really think it's worth unifying the sparse solvers under a common base class. I'll try to find time to do this soon. 