### PR TITLE
Add diagonal scaling method and re-enable LM adaptive + ellipsoidal

### DIFF
--- a/tests/optimizer/nonlinear/common.py
+++ b/tests/optimizer/nonlinear/common.py
@@ -237,6 +237,9 @@ def _check_optimizer_returns_fail_status_on_singular(
         def Av(self, v):
             pass
 
+        def diagonal_scaling(self, v):
+            pass
+
     class MockCostFunction(th.CostFunction):
         def __init__(self, optim_vars, cost_weight):
             super().__init__(cost_weight)

--- a/tests/optimizer/nonlinear/test_levenberg_marquardt.py
+++ b/tests/optimizer/nonlinear/test_levenberg_marquardt.py
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import contextlib
 import pytest  # noqa: F401
 import torch
 
@@ -25,20 +24,17 @@ def mock_objective():
 @pytest.mark.parametrize("ellipsoidal_damping", [True, False])
 @pytest.mark.parametrize("adaptive_damping", [True, False])
 def test_levenberg_marquardt(damping, ellipsoidal_damping, adaptive_damping):
-    with pytest.raises(
-        RuntimeError
-    ) if ellipsoidal_damping and adaptive_damping else contextlib.nullcontext():
-        run_nonlinear_least_squares_check(
-            th.LevenbergMarquardt,
-            {
-                "damping": damping,
-                "ellipsoidal_damping": ellipsoidal_damping,
-                "adaptive_damping": adaptive_damping,
-                "damping_eps": 0.0,
-                __FROM_THESEUS_LAYER_TOKEN__: True,
-            },
-            singular_check=damping < 0.001,
-        )
+    run_nonlinear_least_squares_check(
+        th.LevenbergMarquardt,
+        {
+            "damping": damping,
+            "ellipsoidal_damping": ellipsoidal_damping,
+            "adaptive_damping": adaptive_damping,
+            "damping_eps": 0.0,
+            __FROM_THESEUS_LAYER_TOKEN__: True,
+        },
+        singular_check=damping < 0.001,
+    )
 
 
 def test_ellipsoidal_damping_compatibility(mock_objective):

--- a/theseus/optimizer/dense_linearization.py
+++ b/theseus/optimizer/dense_linearization.py
@@ -72,3 +72,6 @@ class DenseLinearization(Linearization):
 
     def Av(self, v: torch.Tensor) -> torch.Tensor:
         return self.A.bmm(v.unsqueeze(2)).squeeze(2)
+
+    def diagonal_scaling(self, v: torch.Tensor) -> torch.Tensor:
+        return v * self._AtA.diagonal(dim1=1, dim2=2)

--- a/theseus/optimizer/linearization.py
+++ b/theseus/optimizer/linearization.py
@@ -80,3 +80,8 @@ class Linearization(abc.ABC):
     @abc.abstractmethod
     def Av(self, v: torch.Tensor) -> torch.Tensor:
         pass
+
+    # Returns diag(self.A^T @ self.A) * v
+    @abc.abstractmethod
+    def diagonal_scaling(self, v: torch.Tensor) -> torch.Tensor:
+        pass

--- a/theseus/optimizer/sparse_linearization.py
+++ b/theseus/optimizer/sparse_linearization.py
@@ -169,3 +169,15 @@ class SparseLinearization(Linearization):
         return sparse_mv(
             self.num_cols, A_row_ptr, A_col_ind, self.A_val.double(), v.double()
         ).to(v.dtype)
+
+    def diagonal_scaling(self, v: torch.Tensor) -> torch.Tensor:
+        assert v.ndim == 2
+        assert v.shape[1] == self.num_cols
+        A_val = self.A_val
+        diag = torch.zeros(A_val.shape[0], self.num_cols)
+        for row in range(self.num_rows):
+            start = self.A_row_ptr[row]
+            end = self.A_row_ptr[row + 1]
+            columns = self.A_col_ind[start:end]
+            diag[:, columns] += A_val[:, start:end] ** 2
+        return diag * v


### PR DESCRIPTION
This adds a linearization diagonal scaling method and implementations for dense and sparse linearization. The sparse implementation could be faster with a custom kernel, to avoid python loop over rows, but this should be good enough to get an initial implementation. 