### PR TITLE
Add support for masking jacobians of zero weights in the batch

### DIFF
--- a/tests/core/common.py
+++ b/tests/core/common.py
@@ -80,6 +80,9 @@ class MockCostWeight(th.CostWeight):
     def _copy_impl(self, new_name=None):
         return MockCostWeight(self.the_data.copy(), name=new_name)
 
+    def is_zero(self):
+        raise NotImplementedError
+
 
 class NullCostWeight(th.CostWeight):
     def __init__(self):
@@ -96,6 +99,9 @@ class NullCostWeight(th.CostWeight):
 
     def _copy_impl(self, new_name=None):
         return NullCostWeight()
+
+    def is_zero(self):
+        raise NotImplementedError
 
 
 class MockCostFunction(th.CostFunction):

--- a/tests/core/test_robust_cost.py
+++ b/tests/core/test_robust_cost.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import pytest
 
 import torch
 
@@ -9,10 +10,19 @@ import theseus as th
 from tests.core.common import BATCH_SIZES_TO_TEST
 
 
-def _new_robust_cf(batch_size, loss_cls, generator) -> th.RobustCostFunction:
+def _new_robust_cf(
+    batch_size, loss_cls, generator, masked_weight=False
+) -> th.RobustCostFunction:
     v1 = th.rand_se3(batch_size, generator=generator)
     v2 = th.rand_se3(batch_size, generator=generator)
-    w = th.ScaleCostWeight(torch.randn(1, generator=generator))
+    if masked_weight:
+        mask = torch.randint(2, (batch_size, 1), generator=generator)
+        assert mask.any()
+        assert not mask.all()
+        w_tensor = torch.randn(batch_size, 1, generator=generator) * mask
+    else:
+        w_tensor = torch.randn(1, generator=generator)
+    w = th.ScaleCostWeight(w_tensor)
     cf = th.Local(v1, v2, w)
     ll_radius = th.Variable(tensor=torch.randn(1, 1, generator=generator))
     return th.RobustCostFunction(cf, loss_cls, ll_radius)
@@ -38,60 +48,91 @@ def test_robust_cost_weighted_error():
                 expected_rho2 = loss_cls.evaluate(
                     (e * e).sum(dim=1, keepdim=True), robust_cf.log_loss_radius.tensor
                 )
-                assert rho2.allclose(expected_rho2)
+                torch.testing.assert_close(rho2, expected_rho2)
 
 
-def test_robust_cost_grad_form():
+@pytest.mark.parametrize("batch_size", BATCH_SIZES_TO_TEST)
+@pytest.mark.parametrize("loss_cls", [th.WelschLoss, th.HuberLoss])
+def test_robust_cost_grad_form(batch_size, loss_cls):
     generator = torch.Generator()
     generator.manual_seed(0)
     for _ in range(10):
-        for batch_size in BATCH_SIZES_TO_TEST:
-            for loss_cls in [th.WelschLoss, th.HuberLoss]:
-                robust_cf = _new_robust_cf(batch_size, loss_cls, generator)
-                cf = robust_cf.cost_function
-                jacs, e = cf.weighted_jacobians_error()
-                cf_grad = _grad(jacs[0], e)
-                e_norm = (e * e).sum(1, keepdim=True)
-                rho_prime = loss_cls.linearize(e_norm, robust_cf.log_loss_radius.tensor)
-                # `weighted_jacobians_error()` is written so that it results in a
-                # gradient equal to drho_de2 * J^T * e, which in the code is
-                # `rho_prime * cf_grad`.
-                expected_grad = rho_prime.view(-1, 1, 1) * cf_grad
-                rescaled_jac, rescaled_e = robust_cf.weighted_jacobians_error()
-                grad = _grad(rescaled_jac[0], rescaled_e)
-                assert grad.allclose(expected_grad, atol=1e-6)
+        robust_cf = _new_robust_cf(batch_size, loss_cls, generator)
+        cf = robust_cf.cost_function
+        jacs, e = cf.weighted_jacobians_error()
+        cf_grad = _grad(jacs[0], e)
+        e_norm = (e * e).sum(1, keepdim=True)
+        rho_prime = loss_cls.linearize(e_norm, robust_cf.log_loss_radius.tensor)
+        # `weighted_jacobians_error()` is written so that it results in a
+        # gradient equal to drho_de2 * J^T * e, which in the code is
+        # `rho_prime * cf_grad`.
+        expected_grad = rho_prime.view(-1, 1, 1) * cf_grad
+        rescaled_jac, rescaled_e = robust_cf.weighted_jacobians_error()
+        grad = _grad(rescaled_jac[0], rescaled_e)
+        torch.testing.assert_close(grad, expected_grad, atol=1e-6, rtol=1e-6)
 
 
-def test_robust_cost_jacobians():
+@pytest.mark.parametrize("batch_size", BATCH_SIZES_TO_TEST)
+@pytest.mark.parametrize("loss_cls", [th.WelschLoss, th.HuberLoss])
+def test_robust_cost_jacobians(batch_size, loss_cls):
     generator = torch.Generator()
     generator.manual_seed(0)
 
     for _ in range(10):
-        for batch_size in BATCH_SIZES_TO_TEST:
-            for loss_cls in [th.WelschLoss, th.HuberLoss]:
-                robust_cf = _new_robust_cf(batch_size, loss_cls, generator)
-                v1, v2 = robust_cf.cost_function.var, robust_cf.cost_function.target
-                v_aux = v1.copy()
-                ll_radius = robust_cf.log_loss_radius
-                w = robust_cf.cost_function.weight
+        robust_cf = _new_robust_cf(batch_size, loss_cls, generator)
+        v1, v2 = robust_cf.cost_function.var, robust_cf.cost_function.target
+        v_aux = v1.copy()
+        ll_radius = robust_cf.log_loss_radius
+        w = robust_cf.cost_function.weight
 
-                def test_fn(v_data):
-                    v_aux.update(v_data)
-                    new_robust_cf = th.RobustCostFunction(
-                        th.Local(v_aux, v2, w), loss_cls, ll_radius
-                    )
-                    e = new_robust_cf.cost_function.weighted_error()
-                    e_norm = (e * e).sum(1, keepdim=True)
-                    return loss_cls.evaluate(e_norm, ll_radius.tensor) / 2.0
+        def test_fn(v_data):
+            v_aux.update(v_data)
+            new_robust_cf = th.RobustCostFunction(
+                th.Local(v_aux, v2, w), loss_cls, ll_radius
+            )
+            e = new_robust_cf.cost_function.weighted_error()
+            e_norm = (e * e).sum(1, keepdim=True)
+            return loss_cls.evaluate(e_norm, ll_radius.tensor) / 2.0
 
-                aux_id = torch.arange(batch_size)
-                grad_raw_dense = torch.autograd.functional.jacobian(
-                    test_fn, (v1.tensor,)
-                )[0]
-                grad_raw_sparse = grad_raw_dense[aux_id, :, aux_id]
-                expected_grad = v1.project(grad_raw_sparse, is_sparse=True)
+        aux_id = torch.arange(batch_size)
+        grad_raw_dense = torch.autograd.functional.jacobian(test_fn, (v1.tensor,))[0]
+        grad_raw_sparse = grad_raw_dense[aux_id, :, aux_id]
+        expected_grad = v1.project(grad_raw_sparse, is_sparse=True)
 
-                rescaled_jac, rescaled_err = robust_cf.weighted_jacobians_error()
-                grad = _grad(rescaled_jac[0], rescaled_err)
+        rescaled_jac, rescaled_err = robust_cf.weighted_jacobians_error()
+        grad = _grad(rescaled_jac[0], rescaled_err)
 
-                assert grad.allclose(expected_grad, atol=1e-2)
+        torch.testing.assert_close(grad, expected_grad, atol=1e-2, rtol=1e-2)
+
+
+def test_masked_jacobians_called(monkeypatch):
+    rng = torch.Generator()
+    rng.manual_seed(0)
+    robust_cf = _new_robust_cf(128, th.WelschLoss, rng, masked_weight=True)
+    robust_cf._supports_masking = True
+
+    called = [False]
+
+    def masked_jacobians_mock(cost_fn, mask):
+        called[0] = True
+        return cost_fn.jacobians()
+
+    monkeypatch.setattr(
+        th.core.cost_function, "masked_jacobians", masked_jacobians_mock
+    )
+    robust_cf.weighted_jacobians_error()
+    assert called[0]
+
+
+@pytest.mark.parametrize("loss_cls", [th.WelschLoss, th.HuberLoss])
+def test_mask_jacobians(loss_cls):
+    batch_size = 512
+    rng = torch.Generator()
+    rng.manual_seed(0)
+    robust_cf = _new_robust_cf(batch_size, loss_cls, rng, masked_weight=True)
+    jac_expected, err_expected = robust_cf.weighted_jacobians_error()
+    robust_cf._supports_masking = True
+    jac, err = robust_cf.weighted_jacobians_error()
+    torch.testing.assert_close(err, err_expected)
+    for j1, j2 in zip(jac, jac_expected):
+        torch.testing.assert_close(j1, j2)

--- a/tests/core/test_robust_cost.py
+++ b/tests/core/test_robust_cost.py
@@ -16,7 +16,7 @@ def _new_robust_cf(
     v1 = th.rand_se3(batch_size, generator=generator)
     v2 = th.rand_se3(batch_size, generator=generator)
     if masked_weight:
-        mask = torch.randint(2, (batch_size, 1), generator=generator)
+        mask = torch.randint(2, (batch_size, 1), generator=generator).bool()
         assert mask.any()
         assert not mask.all()
         w_tensor = torch.randn(batch_size, 1, generator=generator) * mask

--- a/tests/core/test_vectorizer.py
+++ b/tests/core/test_vectorizer.py
@@ -267,3 +267,89 @@ def test_vectorized_retract():
 
         for v1, v2 in zip(variables, variables_vectorized):
             assert v1.tensor.allclose(v2.tensor)
+
+
+# This solves a very simple objective of the form sum (wi * (xi - ti)) **2, where
+# some wi can be zero with some probability. When vectorize=True, our vectorization
+# class will compute masked batched jacobians. So, this function can be used to test
+# that the solution is the same when this feature is on/off. We also check if we
+# can do a backward pass when this masking is used.
+def _solve_fn_for_masked_jacobians(
+    batch_size, dof, num_costs, weight_cls, vectorize, device
+):
+    rng = torch.Generator()
+    rng.manual_seed(batch_size)
+    obj = th.Objective()
+    variables = [th.Vector(dof=dof, name=f"x{i}") for i in range(num_costs)]
+    targets = [
+        th.Vector(tensor=torch.randn(batch_size, dof, generator=rng), name=f"t{i}")
+        for i in range(num_costs)
+    ]
+    base_tensor = torch.ones(
+        batch_size, dof if weight_cls == th.DiagonalCostWeight else 1, device=device
+    )
+    # Wrapped into a param to pass to torch optimizer if necessary
+    params = [
+        torch.nn.Parameter(
+            base_tensor.clone() * (torch.rand(1, generator=rng).item() > 0.9)
+        )
+        for _ in range(num_costs)
+    ]
+    weights = [weight_cls(params[i]) for i in range(num_costs)]
+    for i in range(num_costs):
+        obj.add(th.Difference(variables[i], targets[i], weights[i], name=f"cf{i}"))
+
+    input_tensors = {
+        f"x{i}": torch.ones(batch_size, dof, device=device) for i in range(num_costs)
+    }
+    layer = th.TheseusLayer(
+        th.LevenbergMarquardt(obj, step_size=0.1, max_iterations=5),
+        vectorize=vectorize,
+    )
+    layer.to(device=device)
+    sol, _ = layer.forward(input_tensors)
+
+    # Check that we can backprop through this without errors
+    if vectorize:
+        optim = torch.optim.Adam(params, lr=1e-4)
+        for _ in range(5):  # do a few steps
+            optim.zero_grad()
+            layer.forward(input_tensors)
+            loss = obj.error_squared_norm().sum()
+            loss.backward()
+            optim.step()
+
+    return sol
+
+
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("dof", [1, 4])
+@pytest.mark.parametrize("num_costs", [1, 64])
+@pytest.mark.parametrize("weight_cls", [th.ScaleCostWeight, th.DiagonalCostWeight])
+def test_masked_jacobians(batch_size, dof, num_costs, weight_cls):
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+    sol1 = _solve_fn_for_masked_jacobians(
+        batch_size, dof, num_costs, weight_cls, True, device
+    )
+    sol2 = _solve_fn_for_masked_jacobians(
+        batch_size, dof, num_costs, weight_cls, False, device
+    )
+
+    for i in range(num_costs):
+        torch.testing.assert_close(sol1[f"x{i}"], sol2[f"x{i}"])
+
+
+def test_masked_jacobians_called(monkeypatch):
+    called = [False]
+
+    def masked_jacobians_mock(cost_fn, mask):
+        called[0] = True
+        return cost_fn.jacobians()
+
+    monkeypatch.setattr(
+        th.core.cost_function, "masked_jacobians", masked_jacobians_mock
+    )
+
+    _solve_fn_for_masked_jacobians(128, 2, 16, th.ScaleCostWeight, True, "cpu")
+    assert called[0]

--- a/tests/embodied/motionmodel/test_double_integrator.py
+++ b/tests/embodied/motionmodel/test_double_integrator.py
@@ -55,6 +55,7 @@ def test_gp_motion_model_cost_weight_weights():
 
 def test_gp_motion_model_cost_weight_copy():
     q_inv = torch.randn(10, 2, 2)
+    q_inv = torch.bmm(q_inv.transpose(1, 2), q_inv)  # make it pos. def.
     dt = torch.rand(1)
     cost_weight = th.eb.GPCostWeight(q_inv, dt, name="gp")
     check_another_theseus_function_is_copy(
@@ -103,6 +104,7 @@ def test_gp_motion_model_cost_function_error_vector_vars():
             dt = th.Variable(torch.rand(1).double())
 
             q_inv = torch.randn(batch_size, dof, dof).double()
+            q_inv = torch.bmm(q_inv.transpose(1, 2), q_inv)  # make it pos. def.
             # won't be used for the test, but it's required by cost_function's constructor
             cost_weight = th.eb.GPCostWeight(q_inv, dt)
             cost_function = th.eb.GPMotionModel(

--- a/tests/optimizer/linearization_test_utils.py
+++ b/tests/optimizer/linearization_test_utils.py
@@ -115,6 +115,9 @@ class MockCostWeight(th.CostWeight):
     def _copy_impl(self, new_name=None):
         raise NotImplementedError
 
+    def is_zero(self):
+        raise NotImplementedError
+
 
 def build_test_objective_and_linear_system():
     # This function creates the an objective that results in the

--- a/theseus/__init__.py
+++ b/theseus/__init__.py
@@ -21,6 +21,8 @@ from .core import (  # usort: skip
     Vectorize,
     WelschLoss,
     as_variable,
+    masked_jacobians,
+    masked_variables,
 )
 from .geometry import (  # usort: skip
     LieGroup,

--- a/theseus/core/__init__.py
+++ b/theseus/core/__init__.py
@@ -3,10 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .cost_function import AutoDiffCostFunction, AutogradMode, CostFunction, ErrFnType
+from .cost_function import (
+    AutoDiffCostFunction,
+    AutogradMode,
+    CostFunction,
+    ErrFnType,
+    masked_jacobians,
+)
 from .cost_weight import CostWeight, DiagonalCostWeight, ScaleCostWeight
 from .objective import Objective
 from .robust_cost_function import RobustCostFunction
 from .robust_loss import HuberLoss, RobustLoss, WelschLoss
-from .variable import Variable, as_variable
+from .variable import Variable, as_variable, masked_variables
 from .vectorizer import Vectorize

--- a/theseus/core/cost_function.py
+++ b/theseus/core/cost_function.py
@@ -46,7 +46,7 @@ def masked_jacobians(
     err = aux_tensor.new_zeros(batch_size, cost_fn.dim())
     with masked_variables(cost_fn_vars, mask):
         masked_jacobians_, err[mask] = cost_fn.jacobians()
-        for (masked_jac, jac) in zip(masked_jacobians_, jacobians):
+        for masked_jac, jac in zip(masked_jacobians_, jacobians):
             jac[mask] = masked_jac
     return jacobians, err
 

--- a/theseus/core/cost_function.py
+++ b/theseus/core/cost_function.py
@@ -104,7 +104,8 @@ class CostFunction(TheseusFunction, abc.ABC):
         done = False
         if self.__supports_masking__:
             try:
-                mask = ~self.weight.is_zero()
+                with torch.no_grad():
+                    mask = ~self.weight.is_zero()
                 if mask.numel() > 1:  # no broadcasting for masks
                     jacobian, err = masked_jacobians(self, mask)
                     done = True

--- a/theseus/core/cost_function.py
+++ b/theseus/core/cost_function.py
@@ -19,7 +19,36 @@ from theseus.geometry.lie_group_check import no_lie_group_check
 
 from .cost_weight import CostWeight, ScaleCostWeight
 from .theseus_function import TheseusFunction
-from .variable import Variable
+from .variable import Variable, masked_variables
+
+
+# This function returns the jacobians and error of the cost function
+# evaluated as if all cost function variables (optim and aux) are
+# masked with the given mask (applied over batch dimension).
+#
+# The mask is applied temporarily, so that the variables will retain
+# their original tensors after the function returns. The jacobians and error
+# will have their normal unmasked shapes, and elements masked out will be
+# set to zero.
+def masked_jacobians(
+    cost_fn: "CostFunction", mask: torch.Tensor
+) -> Tuple[List[torch.Tensor], torch.Tensor]:
+    cost_fn_vars: List[Variable] = cast(
+        List[Variable], list(cost_fn.optim_vars)
+    ) + list(cost_fn.aux_vars)
+    batch_size = max(v.shape[0] for v in cost_fn_vars)
+    aux_tensor = cost_fn_vars[0].tensor
+    # use cost_fn_vars[0] to get dtype and device
+    jacobians = [
+        aux_tensor.new_zeros(batch_size, cost_fn.dim(), v.dof())
+        for v in cost_fn.optim_vars
+    ]
+    err = aux_tensor.new_zeros(batch_size, cost_fn.dim())
+    with masked_variables(cost_fn_vars, mask):
+        masked_jacobians_, err[mask] = cost_fn.jacobians()
+        for (masked_jac, jac) in zip(masked_jacobians_, jacobians):
+            jac[mask] = masked_jac
+    return jacobians, err
 
 
 # A cost function is defined by the variables interacting in it,
@@ -36,6 +65,13 @@ class CostFunction(TheseusFunction, abc.ABC):
     ):
         super().__init__(name=name)
         self._weight = cost_weight
+
+        # For now this is only supported inside vectorized cost functions
+        # When set to true, `weighted_jacobians_error()` first queries the
+        # weight to check indices of zero elements, then uses
+        # `masked_jacobians()` to evaluate jacobians only over non-zero
+        # elements.
+        self.__supports_masking__ = False
 
     @property
     def weight(self) -> CostWeight:
@@ -65,7 +101,17 @@ class CostFunction(TheseusFunction, abc.ABC):
     def weighted_jacobians_error(
         self,
     ) -> Tuple[List[torch.Tensor], torch.Tensor]:
-        jacobian, err = self.jacobians()
+        done = False
+        if self.__supports_masking__:
+            try:
+                mask = ~self.weight.is_zero()
+                if mask.numel() > 1:  # no broadcasting for masks
+                    jacobian, err = masked_jacobians(self, mask)
+                    done = True
+            except NotImplementedError:
+                pass
+        if not done:
+            jacobian, err = self.jacobians()
         return self.weight.weight_jacobians_and_error(jacobian, err)
 
     # Must copy everything
@@ -86,6 +132,14 @@ class CostFunction(TheseusFunction, abc.ABC):
     def to(self, *args, **kwargs):
         super().to(*args, **kwargs)
         self.weight.to(*args, **kwargs)
+
+    @property
+    def _supports_masking(self) -> bool:
+        return self.__supports_masking__
+
+    @_supports_masking.setter
+    def _supports_masking(self, val: bool):
+        self.__supports_masking__ = val
 
 
 # Function protocol for learnable cost functions. `optim_vars` and `aux_vars` are

--- a/theseus/core/cost_weight.py
+++ b/theseus/core/cost_weight.py
@@ -9,9 +9,11 @@ from typing import List, Optional, Sequence, Tuple, Union, cast
 
 import torch
 
-from theseus.constants import EPS
 from .theseus_function import TheseusFunction
 from .variable import Variable, as_variable
+
+
+_ZERO_EPS = 1.0e-15
 
 
 # Abstract class for representing cost weights (aka, precisions, inverse covariance)
@@ -74,7 +76,7 @@ class ScaleCostWeight(CostWeight):
         self.register_aux_vars(["scale"])
 
     def is_zero(self) -> torch.Tensor:
-        return (self.scale.tensor.abs() < EPS).view(-1)
+        return (self.scale.tensor.abs() < _ZERO_EPS).view(-1)
 
     def weight_error(self, error: torch.Tensor) -> torch.Tensor:
         return error * self.scale.tensor
@@ -117,7 +119,7 @@ class DiagonalCostWeight(CostWeight):
         self.register_aux_vars(["diagonal"])
 
     def is_zero(self) -> torch.Tensor:
-        return self.diagonal.tensor.abs().max(dim=1)[0] < EPS
+        return self.diagonal.tensor.abs().max(dim=1)[0] < _ZERO_EPS
 
     def weight_error(self, error: torch.Tensor) -> torch.Tensor:
         return error * self.diagonal.tensor

--- a/theseus/core/cost_weight.py
+++ b/theseus/core/cost_weight.py
@@ -73,7 +73,7 @@ class ScaleCostWeight(CostWeight):
         self.register_aux_vars(["scale"])
 
     def is_zero(self) -> torch.Tensor:
-        return self.scale.tensor == 0
+        return self.scale.tensor.squeeze(1) == 0
 
     def weight_error(self, error: torch.Tensor) -> torch.Tensor:
         return error * self.scale.tensor
@@ -117,7 +117,7 @@ class DiagonalCostWeight(CostWeight):
 
     def is_zero(self) -> torch.Tensor:
         # The minimum of each (diagonal[b] == 0) is True only if all its elements are 0
-        return (self.diagonal.tensor == 0).min(dim=1)[0]
+        return (self.diagonal.tensor == 0).min(dim=1)[0].bool()
 
     def weight_error(self, error: torch.Tensor) -> torch.Tensor:
         return error * self.diagonal.tensor

--- a/theseus/core/robust_cost_function.py
+++ b/theseus/core/robust_cost_function.py
@@ -135,3 +135,12 @@ class RobustCostFunction(CostFunction):
     @weight.setter
     def weight(self, weight: CostWeight):
         self.cost_function.weight = weight
+
+    @property
+    def _supports_masking(self) -> bool:
+        return self.__supports_masking__
+
+    @_supports_masking.setter
+    def _supports_masking(self, val: bool):
+        self.cost_function._supports_masking = val
+        self.__supports_masking__ = val

--- a/theseus/core/vectorizer.py
+++ b/theseus/core/vectorizer.py
@@ -128,6 +128,7 @@ class Vectorize:
             vectorized_cost_fn.weight = base_cost_fn.weight.copy(
                 keep_variable_names=False
             )
+            vectorized_cost_fn._supports_masking = True
             self._vectorized_cost_fns[schema] = vectorized_cost_fn
 
         # Dict[_CostFunctionSchema, List[str]]

--- a/theseus/embodied/motionmodel/double_integrator.py
+++ b/theseus/embodied/motionmodel/double_integrator.py
@@ -118,6 +118,9 @@ class GPCostWeight(CostWeight):
         )
         self.register_aux_vars(["Qc_inv", "dt"])
 
+    def is_zero(self) -> torch.Tensor:
+        raise NotImplementedError
+
     def _compute_cost_weight(self) -> torch.Tensor:
         batch_size, dof, _ = self.Qc_inv.shape
         cost_weight = torch.empty(


### PR DESCRIPTION
With this feature, the vectorizer is able to compute errors and jacobians only over batch indices that are known to be greater than zero. Preliminary tests on a simple problem indicate savings of ~18% compute time both in CPU and GPU. 

For now I made the feature only applicable inside vectorization, although it might be safe to turn off in general. 