### PR TITLE
Add a timer util that adapts to a torch.device.

### DIFF
--- a/theseus/utils/__init__.py
+++ b/theseus/utils/__init__.py
@@ -10,4 +10,4 @@ from .sparse_matrix_utils import (
     split_into_param_sizes,
     tmat_vec,
 )
-from .utils import build_mlp, gather_from_rows_cols, numeric_jacobian
+from .utils import Timer, build_mlp, gather_from_rows_cols, numeric_jacobian

--- a/theseus/utils/utils.py
+++ b/theseus/utils/utils.py
@@ -2,13 +2,13 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-from typing import Callable, List, Optional, Type
+import time
+from typing import Any, Callable, List, Optional, Type
 
 import torch
 import torch.nn as nn
 
-import theseus.geometry as th
+import theseus as th
 
 
 def build_mlp(
@@ -110,3 +110,25 @@ def numeric_jacobian(
     for group_idx in range(len(group_args)):
         jacs.append(_compute(group_idx))
     return jacs
+
+
+class Timer:
+    def __init__(self, device: th.DeviceType) -> None:
+        self.device = torch.device(device)
+        self.elapsed_time = 0.0
+
+    def __enter__(self) -> None:
+        if self.device.type == "cuda":
+            self._start_event = torch.cuda.Event(enable_timing=True)
+            self._end_event = torch.cuda.Event(enable_timing=True)
+            self._start_event.record()
+        else:
+            self._start_time = time.perf_counter_ns()
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self.device.type == "cuda":
+            self._end_event.record()
+            torch.cuda.synchronize()
+            self.elapsed_time = self._start_event.elapsed_time(self._end_event) / 1e3
+        else:
+            self.elapsed_time = (time.perf_counter_ns() - self._start_time) / 1e9

--- a/theseus/utils/utils.py
+++ b/theseus/utils/utils.py
@@ -117,13 +117,14 @@ class Timer:
         self.device = torch.device(device)
         self.elapsed_time = 0.0
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> "Timer":
         if self.device.type == "cuda":
             self._start_event = torch.cuda.Event(enable_timing=True)
             self._end_event = torch.cuda.Event(enable_timing=True)
             self._start_event.record()
         else:
             self._start_time = time.perf_counter_ns()
+        return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self.device.type == "cuda":


### PR DESCRIPTION
Removes boilerplate. Can be used as

```python
from thesus.utils import Timer

with Timer("cuda:0") as timer:
   some_stuff
print(timer.elapsed_time)
```