### PR TITLE
Lie Labs API example

### DIFF
--- a/examples/lie_labs.py
+++ b/examples/lie_labs.py
@@ -70,9 +70,9 @@ g6 = lie.cast(g3_data, lie.SO3)  # alias for as_lietensor()
 assert is_shared(g3_data, g6)
 
 # -- LieTensor.new()
-g7 = g3.new(g3_data)
-assert is_shared(g3_data, g7)  # shares storage
-assert g7.grad_fn is not None  # differentiable
+g7 = g3.new_lietensor(g3_data)
+assert not is_shared(g3_data, g7)  # doesn't share storage
+assert g7.grad_fn is None  # creates a leaf
 
 # ### Lie operations
 v = torch.randn(batch_size, 6)

--- a/examples/lie_labs.py
+++ b/examples/lie_labs.py
@@ -47,7 +47,7 @@ g3_leaf = lie.SO3(g3_data)  # creates a leaf tensor and copies data
 assert g3_leaf.grad_fn is None
 assert not is_shared(g3_leaf, g3_data)
 
-# -- lie.LieTensor() constructor is equilvalent to lie.SO3()
+# -- lie.LieTensor() constructor is equivalent to lie.SO3()
 g3_leaf_2 = lie.LieTensor(g3_data, lie.SO3)
 assert g3_leaf_2.grad_fn is None
 assert not is_shared(g3_leaf_2, g3_data)
@@ -56,7 +56,7 @@ assert not is_shared(g3_leaf_2, g3_data)
 # -- as_lietensor()
 g4 = lie.as_lietensor(g3_data, lie.SO3)
 assert is_shared(g3_data, g4)  # shares storage if possible
-assert g4.grad_fn is not None  # result is not a leaf
+assert g4.grad_fn is not None  # result is not a leaf tensor
 # Calling with a LieTensor returns the same tensor...
 g5 = lie.as_lietensor(g3, lie.SO3)
 assert g5 is g3
@@ -66,7 +66,7 @@ assert g5_double is not g3
 assert not is_shared(g5_double, g3)
 
 # -- cast()
-g6 = lie.cast(g3_data, lie.SO3)  # alias for as_lietensor
+g6 = lie.cast(g3_data, lie.SO3)  # alias for as_lietensor()
 assert is_shared(g3_data, g6)
 
 # -- LieTensor.new()

--- a/examples/lie_labs.py
+++ b/examples/lie_labs.py
@@ -1,0 +1,87 @@
+import torch
+
+import theseus.labs.lie as lie
+import theseus.labs.lie.functional as lieF
+
+batch_size = 5
+
+# ### Lie Tensor creation functions
+g1 = lie.SE3.rand(batch_size, requires_grad=True)
+print(f"Created SE3 tensor with shape {g1.shape}")
+g2 = g1.clone()
+
+# Can create from a tensor as long as it's consistent with the desired ltype
+g3_data = lieF.so3.rand(5)
+g3 = lie.from_tensor(g3_data, lie.SO3)
+
+try:
+    x = lie.from_tensor(torch.zeros(1, 3, 3), lie.SO3)
+except ValueError as e:
+    print(f"ERROR: {e}")
+
+g4 = lie.as_lietensor(g3_data, lie.SO3)
+g5 = lie.cast(g3_data, lie.SO3)  # alias for as_lietensor
+
+# ### Lie operations
+v = torch.randn(batch_size, 6)
+
+# Exponential and logarithmic map
+out1 = lie.SE3.exp(v)  # also lie.exp(v, g1.ltype)
+print(f"Exp map returns a {type(out1)}.")
+out2 = g1.log()  # also lie.log(g1)
+print(f"Log map returns a {type(out2)}.")
+
+# Inverse
+out1 = g1.inv()  # also lie.inv(g1)
+
+# Compose
+# also lie.compose(g1, g2)
+out1 = g1.compose(g2)  # type: ignore
+
+# Differentiable jacobians
+jacs, out = g1.jcompose(g2)  # type: ignore
+print("Jacobians output is a 2-tuple.")
+print("    First element is a list of jacobians, one per group argument.")
+print(f"    For compose this means length {len(jacs)}.")
+print("    The second element of the tuple is the result of the operation itself.")
+print(f"    Which for compose is a {type(out).__name__}.")
+
+# Other options:
+#   * adj(), hat(), vee(), retract(), local(),
+#   * Jacobians: jlog(), jinv(), jexp()
+
+# ### Overriden operators
+# Compose
+out2 = g1 * g2
+torch.testing.assert_close(out1, out2, check_dtype=True)
+
+# Transfrom from (from local to world coordinate frame)
+p = torch.randn(batch_size, 3)
+pt1 = g1.transform_from(p)
+pt2 = g1 @ p
+torch.testing.assert_close(pt1, pt2)
+
+# For convenience, we provide a context to drop all ltype checks, and operate
+# on raw tensor data. However, keep in mind that this is prone to error.
+# Here is one example of how this works.
+with lie.as_euclidean():
+    gg1 = torch.sin(g1)
+# The above is the same as this next call, but the context might be more convenient
+# if one is doing similar hacky stuff on several group objects.
+gg2 = torch.sin(g1._t)
+torch.testing.assert_close(gg1, gg2)
+print("Success: We just did some ops that make no sense for SE3 tensors.")
+
+# ### Lie tensors can also be used as leaf tensors for torch optimizers
+g1 = lie.SE3.rand(1, requires_grad=True)
+g2 = lie.SE3.rand(1)
+
+opt = torch.optim.Adam([g1], lr=0.1)
+
+for i in range(10):
+    opt.zero_grad()
+    d = g1.local(g2)
+    loss = torch.sum(d**2)
+    loss.backward()
+    opt.step()
+    print(f"Iter {i}. Loss: {loss.item(): .3f}")


### PR DESCRIPTION
## Seeking feedback 

This PR has a small example illustrating the current features of our new Lie group tensor library for PyTorch. We are looking for feedback on: 

 1. **API**: Is it easy to use? Any confusing points? Any source of friction?
 2. **Features**: Any features you'd like to see that are not in the planned features below?
 3. **Bugs**: Any bugs you noticed?

## Current features in `alpha`

* A `LieTensor` subclass of `torch.Tensor` serving as entry point.
* SE3 and SO3 groups.
* Implementation of several Lie groups operators, each with custom backward pass: 
    * log and exp maps
    * adjoint, vee, hat operators
    * inverse, compose
    * transform_from (convert point from pose to world coordinates)
* Differentiable jacobians to use in optimization libraries (the jacobians are computed in closed form using `torch`, but w/o a custom backward pass; we rely on torch autograd for this).
* Seamless support for optimizing `LieTensor` parameters using `torch` optimizers. 
* Overloaded operators for `compose` (`*`) and `transform_from` (`@`). 

## Features planned for `beta`

* Support for arbitrary number of batch dimensions and broadcasting (current version assumes a single batch dimension for everything).
* Automatic normalization of operations result (to ensure group properties).
* SO2, SE2, and Sim group support.
* `vmap` support.
* Storage as matrix or quaternion and operators for conversions between these representations (including axis angle).
* cpp and CUDA backends if they lead to significant gains in efficiency.