### PR TITLE
PGO: Rotation/translation swapped in relative pose noise

### DIFF
--- a/examples/configs/pose_graph/pose_graph_synthetic.yaml
+++ b/examples/configs/pose_graph/pose_graph_synthetic.yaml
@@ -4,8 +4,8 @@ profile: True
 savemat: True
 
 num_poses: 256
-rotation_noise: 0.02
 translation_noise: 0.05
+rotation_noise: 0.02
 loop_closure_ratio: 0.2
 loop_closure_outlier_ratio: 0.25
 dataset_size: 256 

--- a/examples/configs/pose_graph/pose_graph_synthetic.yaml
+++ b/examples/configs/pose_graph/pose_graph_synthetic.yaml
@@ -4,8 +4,8 @@ profile: True
 savemat: True
 
 num_poses: 256
-rotation_noise: 0.05
-translation_noise: 0.02
+rotation_noise: 0.02
+translation_noise: 0.05
 loop_closure_ratio: 0.2
 loop_closure_outlier_ratio: 0.25
 dataset_size: 256 

--- a/examples/pose_graph/pose_graph_benchmark.py
+++ b/examples/pose_graph/pose_graph_benchmark.py
@@ -66,6 +66,7 @@ def main(cfg):
         step_size=1,
         linearization_cls=th.SparseLinearization,
         linear_solver_cls=th.CholmodSparseSolver,
+        linear_solver_kwargs={"damping": 1e-6},
         vectorize=True,
     )
 

--- a/examples/pose_graph/pose_graph_synthetic.py
+++ b/examples/pose_graph/pose_graph_synthetic.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# SE(3) convention in this example is translation then rotation.
+
 import cProfile
 import io
 import logging
@@ -121,8 +123,8 @@ def run(cfg: omegaconf.OmegaConf):
     dtype = torch.float64
     pg, _ = theg.PoseGraphDataset.generate_synthetic_3D(
         num_poses=cfg.num_poses,
-        rotation_noise=cfg.rotation_noise,
         translation_noise=cfg.translation_noise,
+        rotation_noise=cfg.rotation_noise,
         loop_closure_ratio=cfg.loop_closure_ratio,
         loop_closure_outlier_ratio=cfg.loop_closure_outlier_ratio,
         batch_size=cfg.batch_size,

--- a/theseus/utils/examples/pose_graph/dataset.py
+++ b/theseus/utils/examples/pose_graph/dataset.py
@@ -237,8 +237,8 @@ class PoseGraphDataset:
     @staticmethod
     def generate_synthetic_3D(
         num_poses: int,
-        rotation_noise: float = 0.05,
         translation_noise: float = 0.1,
+        rotation_noise: float = 0.05,
         loop_closure_ratio: float = 0.2,
         loop_closure_outlier_ratio: float = 0.05,
         max_num_loop_closures: int = 10,
@@ -273,8 +273,9 @@ class PoseGraphDataset:
             gt_relative_pose = th.SE3.exp_map(
                 torch.cat(
                     [
-                        torch.rand(dataset_size, 3, dtype=dtype) - 0.5,
-                        2.0 * torch.rand(dataset_size, 3, dtype=dtype) - 1,
+                        2.0 * torch.rand(dataset_size, 3, dtype=dtype)
+                        - 1,  # translation
+                        torch.rand(dataset_size, 3, dtype=dtype) - 0.5,  # rotation
                     ],
                     dim=1,
                 )
@@ -323,7 +324,7 @@ class PoseGraphDataset:
                             torch.cat(
                                 [
                                     translation_noise
-                                    * (2 * torch.rand(1, 3, dtype=dtype) - 1),
+                                    * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                                     rotation_noise
                                     * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                                 ],
@@ -354,7 +355,7 @@ class PoseGraphDataset:
             noise_pose = th.SE3.exp_map(
                 torch.cat(
                     [
-                        translation_noise * (2 * torch.rand(1, 3, dtype=dtype) - 1),
+                        translation_noise * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                         rotation_noise * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                     ],
                     dim=1,

--- a/theseus/utils/examples/pose_graph/dataset.py
+++ b/theseus/utils/examples/pose_graph/dataset.py
@@ -282,9 +282,9 @@ class PoseGraphDataset:
             noise_relative_pose = th.SE3.exp_map(
                 torch.cat(
                     [
-                        rotation_noise
-                        * (2 * torch.rand(dataset_size, 3, dtype=dtype) - 1),
                         translation_noise
+                        * (2.0 * torch.rand(dataset_size, 3, dtype=dtype) - 1),
+                        rotation_noise
                         * (2.0 * torch.rand(dataset_size, 3, dtype=dtype) - 1),
                     ],
                     dim=1,
@@ -322,9 +322,9 @@ class PoseGraphDataset:
                         noise_relative_pose = th.SE3.exp_map(
                             torch.cat(
                                 [
-                                    rotation_noise
-                                    * (2 * torch.rand(1, 3, dtype=dtype) - 1),
                                     translation_noise
+                                    * (2 * torch.rand(1, 3, dtype=dtype) - 1),
+                                    rotation_noise
                                     * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                                 ],
                                 dim=1,
@@ -354,8 +354,8 @@ class PoseGraphDataset:
             noise_pose = th.SE3.exp_map(
                 torch.cat(
                     [
-                        rotation_noise * (2 * torch.rand(1, 3, dtype=dtype) - 1),
-                        translation_noise * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
+                        translation_noise * (2 * torch.rand(1, 3, dtype=dtype) - 1),
+                        rotation_noise * (2.0 * torch.rand(1, 3, dtype=dtype) - 1),
                     ],
                     dim=1,
                 )


### PR DESCRIPTION
## Motivation and Context

Rotation and translation noise are swapped in the PGO noise addition for `pose_graph/dataset.py` (Issue #481). The change merely fixes this to give a se(3) noise tangent vector [noise_translation, noise_rotation]

## How Has This Been Tested

Minor bug fix, non-breaking change

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
