### PR TITLE
Make SDF boundary value configurable

### DIFF
--- a/theseus/embodied/collision/signed_distance_field.py
+++ b/theseus/embodied/collision/signed_distance_field.py
@@ -23,6 +23,7 @@ class SignedDistanceField2D:
         sdf_data: Optional[Union[torch.Tensor, Variable]] = None,
         occupancy_map: Optional[Union[torch.Tensor, Variable]] = None,
         occupancy_threshold: float = 0.75,
+        sdf_boundary_value: float = 0.0,
     ):
         if occupancy_map is not None:
             if sdf_data is not None:
@@ -45,6 +46,7 @@ class SignedDistanceField2D:
         self.update_data(origin, sdf_data, cell_size)
         self._num_rows = sdf_data.shape[1]
         self._num_cols = sdf_data.shape[2]
+        self.sdf_boundary_value = sdf_boundary_value
 
     def _compute_sdf_data_from_map(
         self,
@@ -216,7 +218,7 @@ class SignedDistanceField2D:
             + hrdiff * lcdiff * gather_sdf(lri, hci)
             + lrdiff * lcdiff * gather_sdf(hri, hci)
         )
-        dist[out_of_bounds_idx] = 0
+        dist[out_of_bounds_idx] = self.sdf_boundary_value
 
         # Compute the jacobians
 


### PR DESCRIPTION
## Motivation and Context
Made the boundary value of sdf configurable.
The default was 0 (i.e. solid wall around the map) but this does not make sense in MPC setting, where we may want to encourage the motion planner to explore outside the current local map.

## How Has This Been Tested
It's not tested yet

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
