### PR TITLE
Add `labs.lie` support for `functorch` and `vmap` pt. 1

### DIFF
--- a/tests/labs/lie/functional/common.py
+++ b/tests/labs/lie/functional/common.py
@@ -126,3 +126,60 @@ def left_project_func(module, group):
         return module._left_project_autograd_fn(group, matrix[sels, ..., sels, :, :])
 
     return func
+
+
+def check_jacrev_unary(group_fns, dim, batch_size, name):
+    if not hasattr(torch, "vmap"):
+        return
+
+    test_fn = getattr(group_fns, name)
+
+    fn_input = (
+        torch.randn(batch_size, dim) if name == "exp" else group_fns.rand(batch_size)
+    )
+
+    def f(t):
+        return group_fns.log(test_fn(t.unsqueeze(0))).squeeze(0)
+
+    j = torch.vmap(torch.func.jacrev(f))(fn_input)
+    jac_vmap = group_fns.left_project(fn_input, j) if name != "exp" else j
+
+    jlog, jtest = [], []
+    group_fns.log(test_fn(fn_input, jacobians=jtest), jacobians=jlog)
+    jac_analytic = jlog[0] @ jtest[0]
+
+    torch.testing.assert_close(jac_vmap, jac_analytic)
+
+
+def check_jacrev_binary(group_fns, batch_size, name):
+    if not hasattr(torch, "vmap"):
+        return
+
+    test_fn = getattr(group_fns, name)
+
+    fn_inputs = (
+        (group_fns.rand(batch_size), torch.randn(batch_size, 3))
+        if name == "transform_from"
+        else (group_fns.rand(batch_size), group_fns.rand(batch_size))
+    )
+
+    def f(t1, t2):
+        op_out = test_fn(t1.unsqueeze(0), t2.unsqueeze(0))
+        if name == "compose":
+            op_out = group_fns.log(op_out)
+        return op_out.squeeze(0)
+
+    jacs_vmap = []
+    for i in range(2):
+        j = torch.vmap(torch.func.jacrev(f, i))(fn_inputs[0], fn_inputs[1])
+        if fn_inputs[i].ndim == 3:  # group input
+            j = group_fns.left_project(fn_inputs[i], j)
+        jacs_vmap.append(j)
+
+    jlog, jtest = [], []
+    out = test_fn(fn_inputs[0], fn_inputs[1], jacobians=jtest)
+    if name == "compose":
+        group_fns.log(out, jacobians=jlog)
+    for i in range(2):
+        jac_analytic = jlog[0] @ jtest[i] if name == "compose" else jtest[i]
+        torch.testing.assert_close(jacs_vmap[i], jac_analytic)

--- a/tests/labs/lie/functional/test_se3.py
+++ b/tests/labs/lie/functional/test_se3.py
@@ -57,3 +57,70 @@ def test_vee(batch_size: int, dtype: torch.dtype):
     torch.testing.assert_close(
         actual_tangent_vector, tangent_vector, atol=TEST_EPS, rtol=TEST_EPS
     )
+
+
+@run_if_labs()
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+@pytest.mark.parametrize("name", ["exp", "inv"])
+def test_jacrev_unary(batch_size, name):
+    if not hasattr(torch, "vmap"):
+        return
+
+    import theseus.labs.lie.functional as lieF
+
+    test_fn = getattr(lieF.SE3, name)
+
+    fn_input = (
+        torch.randn(batch_size, 6) if name == "exp" else lieF.SE3.rand(batch_size)
+    )
+
+    def f(t):
+        return lieF.SE3.log(test_fn(t.unsqueeze(0))).squeeze(0)
+
+    j = torch.vmap(torch.func.jacrev(f))(fn_input)
+    jac_vmap = lieF.SE3.left_project(fn_input, j) if name != "exp" else j
+
+    jlog, jtest = [], []
+    lieF.SE3.log(test_fn(fn_input, jacobians=jtest), jacobians=jlog)
+    jac_analytic = jlog[0] @ jtest[0]
+
+    torch.testing.assert_close(jac_vmap, jac_analytic)
+
+
+@run_if_labs()
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+@pytest.mark.parametrize("name", ["compose"])
+def test_jacrev_binary(batch_size, name):
+    if not hasattr(torch, "vmap"):
+        return
+
+    import theseus.labs.lie.functional as lieF
+
+    test_fn = getattr(lieF.SE3, name)
+
+    fn_inputs = (
+        (lieF.SE3.rand(batch_size), lieF.SE3.rand(batch_size))
+        if name == "compose"
+        else (lieF.SE3.rand(batch_size), torch.randn(batch_size, 3))
+    )
+
+    def f(t1, t2):
+        op_out = test_fn(t1.unsqueeze(0), t2.unsqueeze(0))
+        if name == "compose":
+            op_out = lieF.SE3.log(op_out)
+        return op_out.squeeze(0)
+
+    jacs_vmap = []
+    for i in range(2):
+        j = torch.vmap(torch.func.jacrev(f, i))(fn_inputs[0], fn_inputs[1])
+        if fn_inputs[i].ndim == 3:  # group input
+            j = lieF.SE3.left_project(fn_inputs[i], j)
+        jacs_vmap.append(j)
+
+    jlog, jtest = [], []
+    out = test_fn(fn_inputs[0], fn_inputs[1], jacobians=jtest)
+    if name == "compose":
+        lieF.SE3.log(out, jacobians=jlog)
+    for i in range(2):
+        jac_analytic = jlog[0] @ jtest[i] if name == "compose" else jtest[i]
+        torch.testing.assert_close(jacs_vmap[i], jac_analytic)

--- a/tests/labs/lie/functional/test_se3.py
+++ b/tests/labs/lie/functional/test_se3.py
@@ -77,7 +77,7 @@ def test_jacrev_unary(batch_size, name):
 
 @run_if_labs()
 @pytest.mark.parametrize("batch_size", [1, 10, 100])
-@pytest.mark.parametrize("name", ["compose"])
+@pytest.mark.parametrize("name", ["compose", "transform_from"])
 def test_jacrev_binary(batch_size, name):
     if not hasattr(torch, "vmap"):
         return

--- a/tests/labs/lie/functional/test_se3.py
+++ b/tests/labs/lie/functional/test_se3.py
@@ -8,7 +8,14 @@ import pytest
 import torch
 
 from tests.decorators import run_if_labs
-from .common import BATCH_SIZES_TO_TEST, TEST_EPS, check_lie_group_function, run_test_op
+from .common import (
+    BATCH_SIZES_TO_TEST,
+    TEST_EPS,
+    check_lie_group_function,
+    check_jacrev_binary,
+    check_jacrev_unary,
+    run_test_op,
+)
 
 
 @run_if_labs()
@@ -63,28 +70,9 @@ def test_vee(batch_size: int, dtype: torch.dtype):
 @pytest.mark.parametrize("batch_size", [1, 10, 100])
 @pytest.mark.parametrize("name", ["exp", "inv"])
 def test_jacrev_unary(batch_size, name):
-    if not hasattr(torch, "vmap"):
-        return
-
     import theseus.labs.lie.functional as lieF
 
-    test_fn = getattr(lieF.SE3, name)
-
-    fn_input = (
-        torch.randn(batch_size, 6) if name == "exp" else lieF.SE3.rand(batch_size)
-    )
-
-    def f(t):
-        return lieF.SE3.log(test_fn(t.unsqueeze(0))).squeeze(0)
-
-    j = torch.vmap(torch.func.jacrev(f))(fn_input)
-    jac_vmap = lieF.SE3.left_project(fn_input, j) if name != "exp" else j
-
-    jlog, jtest = [], []
-    lieF.SE3.log(test_fn(fn_input, jacobians=jtest), jacobians=jlog)
-    jac_analytic = jlog[0] @ jtest[0]
-
-    torch.testing.assert_close(jac_vmap, jac_analytic)
+    check_jacrev_unary(lieF.SE3, 6, batch_size, name)
 
 
 @run_if_labs()
@@ -96,31 +84,4 @@ def test_jacrev_binary(batch_size, name):
 
     import theseus.labs.lie.functional as lieF
 
-    test_fn = getattr(lieF.SE3, name)
-
-    fn_inputs = (
-        (lieF.SE3.rand(batch_size), lieF.SE3.rand(batch_size))
-        if name == "compose"
-        else (lieF.SE3.rand(batch_size), torch.randn(batch_size, 3))
-    )
-
-    def f(t1, t2):
-        op_out = test_fn(t1.unsqueeze(0), t2.unsqueeze(0))
-        if name == "compose":
-            op_out = lieF.SE3.log(op_out)
-        return op_out.squeeze(0)
-
-    jacs_vmap = []
-    for i in range(2):
-        j = torch.vmap(torch.func.jacrev(f, i))(fn_inputs[0], fn_inputs[1])
-        if fn_inputs[i].ndim == 3:  # group input
-            j = lieF.SE3.left_project(fn_inputs[i], j)
-        jacs_vmap.append(j)
-
-    jlog, jtest = [], []
-    out = test_fn(fn_inputs[0], fn_inputs[1], jacobians=jtest)
-    if name == "compose":
-        lieF.SE3.log(out, jacobians=jlog)
-    for i in range(2):
-        jac_analytic = jlog[0] @ jtest[i] if name == "compose" else jtest[i]
-        torch.testing.assert_close(jacs_vmap[i], jac_analytic)
+    check_jacrev_binary(lieF.SE3, batch_size, name)

--- a/tests/labs/lie/functional/test_so3.py
+++ b/tests/labs/lie/functional/test_so3.py
@@ -78,7 +78,7 @@ def test_jacrev_unary(batch_size, name):
 
 @run_if_labs()
 @pytest.mark.parametrize("batch_size", [1, 10, 100])
-@pytest.mark.parametrize("name", ["compose"])
+@pytest.mark.parametrize("name", ["compose", "transform_from"])
 def test_jacrev_binary(batch_size, name):
     if not hasattr(torch, "vmap"):
         return

--- a/tests/labs/lie/functional/test_so3.py
+++ b/tests/labs/lie/functional/test_so3.py
@@ -8,7 +8,14 @@ import pytest
 import torch
 
 from tests.decorators import run_if_labs
-from .common import BATCH_SIZES_TO_TEST, TEST_EPS, check_lie_group_function, run_test_op
+from .common import (
+    BATCH_SIZES_TO_TEST,
+    TEST_EPS,
+    check_lie_group_function,
+    check_jacrev_binary,
+    check_jacrev_unary,
+    run_test_op,
+)
 
 
 @run_if_labs()
@@ -58,3 +65,24 @@ def test_vee(batch_size: int, dtype: torch.dtype):
     torch.testing.assert_close(
         actual_tangent_vector, tangent_vector, atol=TEST_EPS, rtol=TEST_EPS
     )
+
+
+@run_if_labs()
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+@pytest.mark.parametrize("name", ["exp", "inv"])
+def test_jacrev_unary(batch_size, name):
+    import theseus.labs.lie.functional as lieF
+
+    check_jacrev_unary(lieF.SO3, 3, batch_size, name)
+
+
+@run_if_labs()
+@pytest.mark.parametrize("batch_size", [1, 10, 100])
+@pytest.mark.parametrize("name", ["compose"])
+def test_jacrev_binary(batch_size, name):
+    if not hasattr(torch, "vmap"):
+        return
+
+    import theseus.labs.lie.functional as lieF
+
+    check_jacrev_binary(lieF.SO3, batch_size, name)

--- a/theseus/labs/lie/functional/__init__.py
+++ b/theseus/labs/lie/functional/__init__.py
@@ -2,5 +2,6 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from .check_contexts import enable_checks
 from .se3_impl import _fns as SE3
 from .so3_impl import _fns as SO3

--- a/theseus/labs/lie/functional/check_contexts.py
+++ b/theseus/labs/lie/functional/check_contexts.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import threading
+from typing import Callable
+
+import torch
+
+
+class _LieGroupCheckContext:
+    contexts = threading.local()
+
+    @classmethod
+    def get_context(cls):
+        if not hasattr(cls.contexts, "check_lie_group"):
+            cls.contexts.check_lie_group = False
+        return cls.contexts.check_lie_group
+
+    @classmethod
+    def set_context(cls, check_lie_group: bool):
+        cls.contexts.check_lie_group = check_lie_group
+
+
+class enable_checks(_LieGroupCheckContext):
+    def __init__(self) -> None:
+        pass
+
+    def __enter__(self) -> None:
+        self.prev = _LieGroupCheckContext.get_context()
+        _LieGroupCheckContext.set_context(True)
+
+    def __exit__(self, typ, value, traceback) -> None:
+        _LieGroupCheckContext.set_context(self.prev)
+
+
+@torch.no_grad()
+def checks_base(tensor: torch.Tensor, check_impl: Callable[[torch.Tensor], None]):
+    if not _LieGroupCheckContext.get_context():
+        return
+    check_impl(tensor)

--- a/theseus/labs/lie/functional/check_contexts.py
+++ b/theseus/labs/lie/functional/check_contexts.py
@@ -39,4 +39,6 @@ class enable_checks(_LieGroupCheckContext):
 def checks_base(tensor: torch.Tensor, check_impl: Callable[[torch.Tensor], None]):
     if not _LieGroupCheckContext.get_context():
         return
+    if torch._C._functorch.is_batchedtensor(tensor):
+        raise RuntimeError("Lie group checks must be turned off to run with vmap.")
     check_impl(tensor)

--- a/theseus/labs/lie/functional/lie_group.py
+++ b/theseus/labs/lie/functional/lie_group.py
@@ -103,6 +103,8 @@ def UnaryOperatorFactory(
 
 
 class BinaryOperator(torch.autograd.Function):
+    generate_vmap_rule = True
+
     @staticmethod
     @abc.abstractmethod
     def forward(ctx, input0, input1):

--- a/theseus/labs/lie/functional/lie_group.py
+++ b/theseus/labs/lie/functional/lie_group.py
@@ -41,9 +41,9 @@ def LeftProjectImplFactory(module):
 
 
 class UnaryOperator(torch.autograd.Function):
-    @classmethod
+    @staticmethod
     @abc.abstractmethod
-    def forward(cls, ctx, input):
+    def forward(ctx, input):
         pass
 
 
@@ -101,9 +101,9 @@ def UnaryOperatorFactory(
 
 
 class BinaryOperator(torch.autograd.Function):
-    @classmethod
+    @staticmethod
     @abc.abstractmethod
-    def forward(cls, ctx, input0, input1):
+    def forward(ctx, input0, input1):
         pass
 
 

--- a/theseus/labs/lie/functional/lie_group.py
+++ b/theseus/labs/lie/functional/lie_group.py
@@ -43,9 +43,23 @@ def LeftProjectImplFactory(module):
 class UnaryOperator(torch.autograd.Function):
     generate_vmap_rule = True
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def forward(ctx, input):
+    def _forward_impl(cls, tensor: torch.Tensor) -> torch.Tensor:
+        pass
+
+    @classmethod
+    def forward(cls, *args):
+        assert len(args) in [1, 2]
+        if len(args) == 1:  # torch >= 2.0, args is (tensor,)
+            output = cls._forward_impl(args[0])
+        else:  # args is (ctx, tensor)
+            output = cls._forward_impl(args[1])
+            cls.setup_context(args[0], (args[1],), output)
+        return output
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
         pass
 
 
@@ -105,9 +119,23 @@ def UnaryOperatorFactory(
 class BinaryOperator(torch.autograd.Function):
     generate_vmap_rule = True
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def forward(ctx, input0, input1):
+    def _forward_impl(cls, input0, input1):
+        pass
+
+    @classmethod
+    def forward(cls, *args):
+        assert len(args) in [2, 3]
+        if len(args) == 2:  # torch >= 2.0, args is (tensor1, tensor2)
+            output = cls._forward_impl(args[0], args[1])
+        else:  # args is (ctx, tensor)
+            output = cls._forward_impl(args[1], args[2])
+            cls.setup_context(args[0], (args[1], args[2]), output)
+        return output
+
+    @classmethod
+    def setup_context(cls, ctx, inputs, outputs):
         pass
 
 

--- a/theseus/labs/lie/functional/lie_group.py
+++ b/theseus/labs/lie/functional/lie_group.py
@@ -41,6 +41,8 @@ def LeftProjectImplFactory(module):
 
 
 class UnaryOperator(torch.autograd.Function):
+    generate_vmap_rule = True
+
     @staticmethod
     @abc.abstractmethod
     def forward(ctx, input):

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -8,6 +8,7 @@ from typing import cast, List, Tuple, Optional
 
 from . import constants
 from . import lie_group, so3_impl as SO3
+from .check_contexts import checks_base
 from .utils import get_module
 
 
@@ -19,12 +20,14 @@ _module = get_module(__name__)
 
 
 def check_group_tensor(tensor: torch.Tensor):
-    with torch.no_grad():
-        if tensor.ndim != 3 or tensor.shape[1:] != (3, 4):
+    def _impl(t_: torch.Tensor):
+        if t_.ndim != 3 or t_.shape[1:] != (3, 4):
             raise ValueError(
-                f"SE3 data tensors can only be 3x4 matrices, but got shape {tensor.shape}."
+                f"SE3 data tensors can only be 3x4 matrices, but got shape {t_.shape}."
             )
-    SO3.check_group_tensor(tensor[:, :, :3])
+        SO3.check_group_tensor(t_[:, :, :3])
+
+    checks_base(tensor, _impl)
 
 
 def check_transform_tensor(tensor: torch.Tensor):
@@ -32,40 +35,61 @@ def check_transform_tensor(tensor: torch.Tensor):
 
 
 def check_tangent_vector(tangent_vector: torch.Tensor):
-    _check = tangent_vector.ndim == 3 and tangent_vector.shape[1:] == (6, 1)
-    _check |= tangent_vector.ndim == 2 and tangent_vector.shape[1] == 6
-    if not _check:
-        raise ValueError(
-            f"Tangent vectors of SE3 should be 6-D vectors, but got shape {tangent_vector.shape}."
-        )
+    def _impl(t_: torch.Tensor):
+        _check = t_.ndim == 3 and t_.shape[1:] == (6, 1)
+        _check |= t_.ndim == 2 and t_.shape[1] == 6
+        if not _check:
+            raise ValueError(
+                f"Tangent vectors of SE3 should be 6-D vectors, "
+                f"but got shape {t_.shape}."
+            )
+
+    checks_base(tangent_vector, _impl)
 
 
 def check_hat_matrix(matrix: torch.Tensor):
-    if matrix.ndim != 3 or matrix.shape[1:] != (4, 4):
-        raise ValueError("Hat matrices of SE(3) can only be 3x4 matrices")
+    def _impl(t_: torch.Tensor):
+        if t_.ndim != 3 or t_.shape[1:] != (4, 4):
+            raise ValueError("Hat matrices of SE(3) can only be 3x4 matrices")
 
-    if matrix[:, -1].abs().max() > constants._SE3_NEAR_ZERO_EPS[matrix.dtype]:
-        raise ValueError("The last row for hat matrices of SE(3) must be zero")
+        if t_[:, -1].abs().max() > constants._SE3_NEAR_ZERO_EPS[t_.dtype]:
+            raise ValueError("The last row for hat matrices of SE(3) must be zero")
 
-    SO3.check_hat_matrix(matrix[:, :3, :3])
+        SO3.check_hat_matrix(t_[:, :3, :3])
+
+    checks_base(matrix, _impl)
 
 
 def check_lift_matrix(matrix: torch.Tensor):
-    return matrix.shape[-1] == 6
+    def _impl(t_: torch.Tensor):
+        if not t_.shape[-1] == 6:
+            raise ValueError("Inconsistent shape for the matrix to lift.")
+
+    checks_base(matrix, _impl)
 
 
 def check_project_matrix(matrix: torch.Tensor):
-    return matrix.shape[-2:] == (3, 4)
+    def _impl(t_: torch.Tensor):
+        if not t_.shape[-2:] == (3, 4):
+            raise ValueError("Inconsistent shape for the matrix to project.")
+
+    checks_base(matrix, _impl)
 
 
 def check_left_act_matrix(matrix: torch.Tensor):
-    if matrix.shape[-2] != 3:
-        raise ValueError("Inconsistent shape for the matrix.")
+    def _impl(t_: torch.Tensor):
+        if t_.shape[-2] != 3:
+            raise ValueError("Inconsistent shape for the matrix.")
+
+    checks_base(matrix, _impl)
 
 
 def check_left_project_matrix(matrix: torch.Tensor):
-    if matrix.shape[-2:] != (3, 4):
-        raise ValueError("Inconsistent shape for the matrix.")
+    def _impl(t_: torch.Tensor):
+        if t_.shape[-2:] != (3, 4):
+            raise ValueError("Inconsistent shape for the matrix.")
+
+    checks_base(matrix, _impl)
 
 
 # -----------------------------------------------------------------------------
@@ -854,8 +878,7 @@ _jtransform_from_autograd_fn = _jtransform_from_impl
 # Lift
 # -----------------------------------------------------------------------------
 def _lift_impl(matrix: torch.Tensor) -> torch.Tensor:
-    if not check_lift_matrix(matrix):
-        raise ValueError("Inconsistent shape for the matrix to lift.")
+    check_lift_matrix(matrix)
     ret = matrix.new_zeros(matrix.shape[:-1] + (3, 4))
     ret[..., :, :3] = SO3._lift_impl(matrix[..., 3:])
     ret[..., :, 3] = matrix[..., :3]
@@ -890,9 +913,7 @@ lift, jlift = lie_group.UnaryOperatorFactory(_module, "lift")
 # Project
 # -----------------------------------------------------------------------------
 def _project_impl(matrix: torch.Tensor) -> torch.Tensor:
-    if not check_project_matrix(matrix):
-        raise ValueError("Inconsistent shape for the matrix to project.")
-
+    check_project_matrix(matrix)
     return torch.stack(
         (
             matrix[..., 0, 3],

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -331,15 +331,15 @@ def _jexp_impl(
 
 
 class Exp(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _exp_impl(tangent_vector)
         ctx.save_for_backward(tangent_vector, ret)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         tangent_vector: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
         if not hasattr(ctx, "jacobians"):
@@ -561,15 +561,15 @@ def _jlog_impl(group: torch.Tensor) -> Tuple[List[torch.Tensor], torch.Tensor]:
 
 
 class Log(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         tangent_vector = _log_impl(group)
         ctx.save_for_backward(tangent_vector, group)
         return tangent_vector
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[1]
         if not hasattr(ctx, "jacobians"):
             ctx.jacobians: torch.Tensor = _jlog_impl(group)[0][0]
@@ -604,14 +604,14 @@ _jadjoint_impl = None
 
 
 class Adjoint(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         ctx.save_for_backward(group)
         return _adjoint_impl(group)
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[0]
         grad_input_rot = (
             grad_output[:, :3, :3]
@@ -642,14 +642,14 @@ _jinverse_impl = lie_group.JInverseImplFactory(_module)
 
 
 class Inverse(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         ctx.save_for_backward(group)
         return _inverse_impl(group)
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[0]
         grad_input_rot = grad_output[:, :, :3].transpose(1, 2) - group[
             :, :, 3:
@@ -680,14 +680,14 @@ _jhat_impl = None
 
 
 class Hat(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _hat_impl(tangent_vector)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return torch.stack(
             (
@@ -729,14 +729,14 @@ _jvee_impl = None
 
 
 class Vee(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _vee_impl(tangent_vector)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         grad_input = grad_output.new_zeros(grad_output.shape[0], 4, 4)
         grad_input[:, :3, 3] = grad_output[:, :3]
@@ -777,16 +777,16 @@ def _jcompose_impl(
 
 
 class Compose(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group0, group1):
+    @staticmethod
+    def forward(ctx, group0, group1):
         group0: torch.Tensor = cast(torch.Tensor, group0)
         group1: torch.Tensor = cast(torch.Tensor, group1)
         ret = _compose_impl(group0, group1)
         ctx.save_for_backward(group0, group1)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group0: torch.Tensor = ctx.saved_tensors[0]
         group1: torch.Tensor = ctx.saved_tensors[1]
         grad_input0 = torch.cat(
@@ -826,16 +826,16 @@ def _jtransform_from_impl(
 
 
 class TransformFrom(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, tensor):
+    @staticmethod
+    def forward(ctx, group, tensor):
         group: torch.Tensor = cast(torch.Tensor, group)
         tensor: torch.Tensor = cast(torch.Tensor, tensor)
         ret = _transform_from_impl(group, tensor)
         ctx.save_for_backward(group, tensor)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[0]
         tensor: torch.Tensor = ctx.saved_tensors[1]
         grad_output: torch.Tensor = grad_output.view(-1, 3, 1)
@@ -868,14 +868,14 @@ _jlift_impl = None
 
 
 class Lift(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, matrix):
+    @staticmethod
+    def forward(ctx, matrix):
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _lift_impl(matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return project(grad_output)
 
@@ -911,14 +911,14 @@ _jproject_impl = None
 
 
 class Project(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, matrix):
+    @staticmethod
+    def forward(ctx, matrix):
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _project_impl(matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return lift(grad_output)
 
@@ -948,16 +948,16 @@ def _left_act_backward_helper(group, matrix, grad_output) -> torch.Tensor:
 
 
 class LeftAct(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, matrix):
+    @staticmethod
+    def forward(ctx, group, matrix):
         group: torch.Tensor = cast(torch.Tensor, group)
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _left_act_impl(group, matrix)
         ctx.save_for_backward(group, matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group, matrix = ctx.saved_tensors
         jac_g = _left_act_backward_helper(group, matrix, grad_output)
         jac_mat = torch.einsum("nji, n...jk->n...ik", group[:, :, :3], grad_output)
@@ -989,16 +989,16 @@ def _left_project_backward_helper(group, matrix, grad_output_lifted) -> torch.Te
 
 
 class LeftProject(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, matrix):
+    @staticmethod
+    def forward(ctx, group, matrix):
         group: torch.Tensor = cast(torch.Tensor, group)
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _left_project_impl(group, matrix)
         ctx.save_for_backward(group, matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group, matrix = ctx.saved_tensors
         grad_output_lifted = lift(grad_output)
         jac_rot = torch.einsum("n...ij,n...kj->n...ik", matrix, grad_output_lifted)

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -1029,17 +1029,6 @@ _left_project_impl = lie_group.LeftProjectImplFactory(_module)
 _jleft_project_impl = None
 
 
-def _left_project_backward_helper(group, matrix, grad_output_lifted) -> torch.Tensor:
-    group_inv = _inverse_impl(group)
-    jac_ginv = _left_act_backward_helper(group_inv, matrix, grad_output_lifted)
-    jac_rot = jac_ginv[:, :, :3].transpose(1, 2) - group[:, :, 3:] @ jac_ginv[
-        :, :, 3:
-    ].transpose(1, 2)
-    jac_t = -group[:, :, :3] @ jac_ginv[:, :, 3:]
-    jac_g = torch.cat((jac_rot, jac_t), dim=-1)
-    return jac_g
-
-
 class LeftProject(lie_group.BinaryOperator):
     @staticmethod
     def forward(ctx, group, matrix):

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -874,12 +874,16 @@ def _jtransform_from_impl(
 
 class TransformFrom(lie_group.BinaryOperator):
     @staticmethod
-    def forward(ctx, group, tensor):
+    def forward(group, tensor):
         group: torch.Tensor = cast(torch.Tensor, group)
         tensor: torch.Tensor = cast(torch.Tensor, tensor)
         ret = _transform_from_impl(group, tensor)
-        ctx.save_for_backward(group, tensor)
         return ret
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        # inputs is (group, tensor)
+        ctx.save_for_backward(inputs[0], inputs[1])
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -666,11 +666,16 @@ _jinverse_impl = lie_group.JInverseImplFactory(_module)
 
 
 class Inverse(lie_group.UnaryOperator):
+    generate_vmap_rule = True
+
     @staticmethod
-    def forward(ctx, group):
+    def forward(group):
         group: torch.Tensor = cast(torch.Tensor, group)
-        ctx.save_for_backward(group)
         return _inverse_impl(group)
+
+    @staticmethod
+    def setup_context(ctx, inputs, _):
+        ctx.save_for_backward(inputs[0])  # inputs is (group,)
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/theseus/labs/lie/functional/se3_impl.py
+++ b/theseus/labs/lie/functional/se3_impl.py
@@ -370,9 +370,7 @@ class Exp(lie_group.UnaryOperator):
     def backward(cls, ctx, grad_output):
         tangent_vector: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
-        if not hasattr(ctx, "jacobians"):
-            ctx.jacobians: torch.Tensor = _jexp_impl(tangent_vector)[0][0]
-        jacs = ctx.jacobians
+        jacs = _jexp_impl(tangent_vector)[0][0]
         dg = group[..., :3].transpose(-2, -1) @ grad_output
         grad_input = jacs.transpose(-2, -1) @ torch.stack(
             (
@@ -599,7 +597,6 @@ class Log(lie_group.UnaryOperator):
     def setup_context(cls, ctx, inputs, outputs):
         # inputs is (group,). outputs is tangent_vector
         ctx.save_for_backward(outputs, inputs[0])
-        pass
 
     @classmethod
     def backward(cls, ctx, grad_output):

--- a/theseus/labs/lie/functional/so3_impl.py
+++ b/theseus/labs/lie/functional/so3_impl.py
@@ -541,10 +541,14 @@ _jhat_impl = None
 
 class Hat(lie_group.UnaryOperator):
     @staticmethod
-    def forward(ctx, tangent_vector):
+    def forward(tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _hat_impl(tangent_vector)
         return ret
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        pass
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/theseus/labs/lie/functional/so3_impl.py
+++ b/theseus/labs/lie/functional/so3_impl.py
@@ -298,9 +298,7 @@ class Exp(lie_group.UnaryOperator):
     def backward(cls, ctx, grad_output):
         tangent_vector: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
-        if not hasattr(ctx, "jacobians"):
-            ctx.jacobians: torch.Tensor = _jexp_impl(tangent_vector)[0][0]
-        jacs = ctx.jacobians
+        jacs = _jexp_impl(tangent_vector)[0][0]
         dR = group.transpose(-2, -1) @ grad_output
         grad_input = jacs.transpose(-2, -1) @ torch.stack(
             (
@@ -460,11 +458,9 @@ class Log(lie_group.UnaryOperator):
     @classmethod
     def backward(cls, ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[1]
-        if not hasattr(ctx, "jacobians"):
-            ctx.jacobians: torch.Tensor = 0.5 * _jlog_impl(group)[0][0]
-
+        jacobians = 0.5 * _jlog_impl(group)[0][0]
         temp = _lift_autograd_fn(
-            (ctx.jacobians.transpose(-2, -1) @ grad_output.unsqueeze(-1)).squeeze(-1)
+            (jacobians.transpose(-2, -1) @ grad_output.unsqueeze(-1)).squeeze(-1)
         )
         return torch.einsum("nij,n...jk->n...ik", group, temp)
 
@@ -811,11 +807,7 @@ class QuaternionToRotation(lie_group.UnaryOperator):
     def backward(cls, ctx, grad_output):
         quaternion: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
-        if not hasattr(ctx, "jacobians"):
-            ctx.jacobians: torch.Tensor = _jquaternion_to_rotation_impl(quaternion)[0][
-                0
-            ]
-        jacs = ctx.jacobians
+        jacs = _jquaternion_to_rotation_impl(quaternion)[0][0]
         dR = group.transpose(1, 2) @ grad_output
         grad_input = jacs.transpose(1, 2) @ torch.stack(
             (

--- a/theseus/labs/lie/functional/so3_impl.py
+++ b/theseus/labs/lie/functional/so3_impl.py
@@ -265,15 +265,15 @@ def _jexp_impl(
 
 
 class Exp(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _exp_impl(tangent_vector)
         ctx.save_for_backward(tangent_vector, ret)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         tangent_vector: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
         if not hasattr(ctx, "jacobians"):
@@ -424,15 +424,15 @@ def _jlog_impl(group: torch.Tensor) -> Tuple[List[torch.Tensor], torch.Tensor]:
 
 
 class Log(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         tangent_vector = _log_impl(group)
         ctx.save_for_backward(tangent_vector, group)
         return tangent_vector
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[1]
         if not hasattr(ctx, "jacobians"):
             ctx.jacobians: torch.Tensor = 0.5 * _jlog_impl(group)[0][0]
@@ -461,13 +461,13 @@ _jadjoint_impl = None
 
 
 class Adjoint(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         return _adjoint_impl(group)
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         return grad_output
 
 
@@ -487,13 +487,13 @@ _jinverse_impl = lie_group.JInverseImplFactory(_module)
 
 
 class Inverse(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, group):
+    @staticmethod
+    def forward(ctx, group):
         group: torch.Tensor = cast(torch.Tensor, group)
         return _inverse_impl(group)
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         return grad_output.transpose(1, 2)
 
 
@@ -522,14 +522,14 @@ _jhat_impl = None
 
 
 class Hat(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _hat_impl(tangent_vector)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return torch.stack(
             (
@@ -565,14 +565,14 @@ _jvee_impl = None
 
 
 class Vee(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, tangent_vector):
+    @staticmethod
+    def forward(ctx, tangent_vector):
         tangent_vector: torch.Tensor = cast(torch.Tensor, tangent_vector)
         ret = _vee_impl(tangent_vector)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return 0.5 * _hat_autograd_fn(grad_output)
 
@@ -605,16 +605,16 @@ def _jcompose_impl(
 
 
 class Compose(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group0, group1):
+    @staticmethod
+    def forward(ctx, group0, group1):
         group0: torch.Tensor = cast(torch.Tensor, group0)
         group1: torch.Tensor = cast(torch.Tensor, group1)
         ret = _compose_impl(group0, group1)
         ctx.save_for_backward(group0, group1)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group0, group1 = ctx.saved_tensors
         return (
             grad_output @ group1.transpose(1, 2),
@@ -650,16 +650,16 @@ def _jtransform_from_impl(
 
 
 class TransformFrom(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, tensor):
+    @staticmethod
+    def forward(ctx, group, tensor):
         group: torch.Tensor = cast(torch.Tensor, group)
         tensor: torch.Tensor = cast(torch.Tensor, tensor)
         ret = _transform_from_impl(group, tensor)
         ctx.save_for_backward(group, tensor)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[0]
         tensor: torch.Tensor = ctx.saved_tensors[1]
         grad_output: torch.Tensor = grad_output.view(-1, 3, 1)
@@ -758,15 +758,15 @@ def _jquaternion_to_rotation_impl(
 
 
 class QuaternionToRotation(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, quaternion):
+    @staticmethod
+    def forward(ctx, quaternion):
         quaternion: torch.Tensor = cast(torch.Tensor, quaternion)
         ret = _quaternion_to_rotation_impl(quaternion)
         ctx.save_for_backward(quaternion, ret)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         quaternion: torch.Tensor = ctx.saved_tensors[0]
         group: torch.Tensor = ctx.saved_tensors[1]
         if not hasattr(ctx, "jacobians"):
@@ -813,14 +813,14 @@ _jlift_impl = None
 
 
 class Lift(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, matrix):
+    @staticmethod
+    def forward(ctx, matrix):
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _lift_impl(matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return _project_autograd_fn(grad_output)
 
@@ -851,14 +851,14 @@ _jproject_impl = None
 
 
 class Project(lie_group.UnaryOperator):
-    @classmethod
-    def forward(cls, ctx, matrix):
+    @staticmethod
+    def forward(ctx, matrix):
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _project_impl(matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         grad_output: torch.Tensor = cast(torch.Tensor, grad_output)
         return _lift_autograd_fn(grad_output)
 
@@ -878,16 +878,16 @@ def _left_act_impl(group: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
 
 
 class LeftAct(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, matrix):
+    @staticmethod
+    def forward(ctx, group, matrix):
         group: torch.Tensor = cast(torch.Tensor, group)
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _left_act_impl(group, matrix)
         ctx.save_for_backward(group, matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group, matrix = ctx.saved_tensors
         jac_g = torch.einsum("n...ij,n...kj->n...ik", grad_output, matrix)
         if matrix.ndim > 3:
@@ -909,16 +909,16 @@ _jleft_project_impl = None
 
 
 class LeftProject(lie_group.BinaryOperator):
-    @classmethod
-    def forward(cls, ctx, group, matrix):
+    @staticmethod
+    def forward(ctx, group, matrix):
         group: torch.Tensor = cast(torch.Tensor, group)
         matrix: torch.Tensor = cast(torch.Tensor, matrix)
         ret = _left_project_impl(group, matrix)
         ctx.save_for_backward(group, matrix)
         return ret
 
-    @classmethod
-    def backward(cls, ctx, grad_output):
+    @staticmethod
+    def backward(ctx, grad_output):
         group, matrix = ctx.saved_tensors
         grad_output_lifted = _lift_autograd_fn(grad_output)
         jac_g = -torch.einsum("n...ij,n...jk->n...ik", matrix, grad_output_lifted)

--- a/theseus/labs/lie/functional/so3_impl.py
+++ b/theseus/labs/lie/functional/so3_impl.py
@@ -525,12 +525,12 @@ _jinverse_autograd_fn = _jinverse_impl
 def _hat_impl(tangent_vector: torch.Tensor) -> torch.Tensor:
     check_tangent_vector(tangent_vector)
     matrix = tangent_vector.new_zeros(tangent_vector.shape[0], 3, 3)
-    matrix[:, 0, 1] = -tangent_vector[:, 2].view(-1)
-    matrix[:, 0, 2] = tangent_vector[:, 1].view(-1)
-    matrix[:, 1, 2] = -tangent_vector[:, 0].view(-1)
-    matrix[:, 1, 0] = tangent_vector[:, 2].view(-1)
-    matrix[:, 2, 0] = -tangent_vector[:, 1].view(-1)
-    matrix[:, 2, 1] = tangent_vector[:, 0].view(-1)
+    matrix[..., 0, 1] = -tangent_vector[..., 2].view(-1)
+    matrix[..., 0, 2] = tangent_vector[..., 1].view(-1)
+    matrix[..., 1, 2] = -tangent_vector[..., 0].view(-1)
+    matrix[..., 1, 0] = tangent_vector[..., 2].view(-1)
+    matrix[..., 2, 0] = -tangent_vector[..., 1].view(-1)
+    matrix[..., 2, 1] = tangent_vector[..., 0].view(-1)
 
     return matrix
 

--- a/theseus/labs/lie/lie_tensor.py
+++ b/theseus/labs/lie/lie_tensor.py
@@ -225,12 +225,11 @@ class LieTensor(_LieTensorBase):
                 if ret.ndim == 2:
                     ret = ret._t.unsqueeze(0)
             return tree_map_only(torch.Tensor, lambda x: from_tensor(x, ltype), ret)
-        return NotImplemented
-        # raise NotImplementedError(
-        #     "Tried to call a torch function not supported by LieTensor. "
-        #     "If trying to operate on the raw tensor data, please use group._t, "
-        #     "or run inside the context lie.as_euclidean()."
-        # )
+        raise NotImplementedError(
+            "Tried to call a torch function not supported by LieTensor. "
+            "If trying to operate on the raw tensor data, please use group._t, "
+            "or run inside the context lie.as_euclidean()."
+        )
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/theseus/labs/lie/lie_tensor.py
+++ b/theseus/labs/lie/lie_tensor.py
@@ -156,6 +156,7 @@ class LieTensor(_LieTensorBase):
         torch.Tensor.is_sparse.__get__,  # type: ignore
         torch.Tensor.is_quantized.__get__,  # type: ignore
         torch.Tensor.grad.__get__,  # type: ignore
+        torch.Tensor.grad.__set__,  # type: ignore
         torch.Tensor.layout.__get__,  # type: ignore
         torch.Tensor.requires_grad.__get__,  # type: ignore
         torch.Tensor.retains_grad.__get__,  # type: ignore
@@ -224,11 +225,12 @@ class LieTensor(_LieTensorBase):
                 if ret.ndim == 2:
                     ret = ret._t.unsqueeze(0)
             return tree_map_only(torch.Tensor, lambda x: from_tensor(x, ltype), ret)
-        raise NotImplementedError(
-            "Tried to call a torch function not supported by LieTensor. "
-            "If trying to operate on the raw tensor data, please use group._t, "
-            "or run inside the context lie.as_euclidean()."
-        )
+        return NotImplemented
+        # raise NotImplementedError(
+        #     "Tried to call a torch function not supported by LieTensor. "
+        #     "If trying to operate on the raw tensor data, please use group._t, "
+        #     "or run inside the context lie.as_euclidean()."
+        # )
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):


### PR DESCRIPTION
Adds `vmap` support for the functional package of `labs.lie`. I have only tested that `vmap + jacrev` works correctly on `inv`, `exp`, `log`, `compose`.

Requires PyTorch >= 2.0, but backward compatibility is maintained. 

TODO:
- [ ] test other operators (maybe? need to figure out what a good test for those is, @fantaosha)
- [x] remove remaining jacobians cache after confirming they are not necessary with `jacrev`
- [x] incorporate `transform_from` fixes in #505