### PR TITLE
Fix setup.py for windows by explicitly mentioning cusparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ if compile_cuda_support:
                 str(root_dir / "theseus" / "extlib" / "cusolver_sp_defs.cpp"),
             ],
             include_dirs=[str(root_dir)],
-            libraries=["cusolver"],
+            libraries=["cusolver", "cusparse"],
         ),
     ]
 else:


### PR DESCRIPTION
## Motivation and Context

Currently, when building from source on windows with CUDA 11.8 and Visual Studio 2022, one gets the following error - noticeably, this build command mentions `cusolver.lib c10.lib torch.lib torch_cpu.lib` etc, but not cusparse.lib. I haven't ran every test but this works with the basic ones that don't require installing a lot of dependencies, like theseus layer.

```cmd
    "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\Aidan\.conda\envs\311\Lib\site-packages\torch\lib "/LIBPATH:C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64" /LIBPATH:C:\Users\Aidan\.conda\envs\311\libs /LIBPATH:C:\Users\Aidan\.conda\envs\311 /LIBPATH:C:\Users\Aidan\.conda\envs\311\PCbuild\amd64 "/LIBPATH:C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64" "/LIBPATH:C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.34.31933\ATLMFC\lib\x64" "/LIBPATH:C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.34.31933\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22000.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22000.0\\um\x64" "/LIBPATH:C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64" cusolver.lib c10.lib torch.lib torch_cpu.lib torch_python.lib cudart.lib c10_cuda.lib torch_cuda.lib /EXPORT:PyInit_cusolver_lu_solver E:\redacted\third_party\theseus\build\temp.win-amd64-cpython-311\Release\redacted\third_party\theseus\theseus\extlib\cusolver_lu_solver.obj E:\redacted\third_party\theseus\build\temp.win-amd64-cpython-311\Release\redacted\third_party\theseus\theseus\extlib\cusolver_sp_defs.obj /OUT:build\lib.win-amd64-cpython-311\theseus\extlib\cusolver_lu_solver.cp311-win_amd64.pyd /IMPLIB:E:\redacted\third_party\theseus\build\temp.win-amd64-cpython-311\Release\redacted\third_party\theseus\theseus\extlib\cusolver_lu_solver.cp311-win_amd64.lib
       Creating library E:\redacted\third_party\theseus\build\temp.win-amd64-cpython-311\Release\redacted\third_party\theseus\theseus\extlib\cusolver_lu_solver.cp311-win_amd64.lib and object E:\redacted\third_party\theseus\build\temp.win-amd64-cpython-311\Release\redacted\third_party\theseus\theseus\extlib\cusolver_lu_solver.cp311-win_amd64.exp
    cusolver_lu_solver.obj : error LNK2001: unresolved external symbol cusparseGetErrorString
    cusolver_lu_solver.obj : error LNK2001: unresolved external symbol cusparseSetMatType
    cusolver_lu_solver.obj : error LNK2001: unresolved external symbol cusparseCreateMatDescr
    cusolver_lu_solver.obj : error LNK2001: unresolved external symbol cusparseDestroyMatDescr
    cusolver_lu_solver.obj : error LNK2001: unresolved external symbol cusparseSetMatIndexBase
    build\lib.win-amd64-cpython-311\theseus\extlib\cusolver_lu_solver.cp311-win_amd64.pyd : fatal error LNK1120: 5 unresolved externals
    error: command 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.34.31933\\bin\\HostX64\\x64\\link.exe' failed with exit code 1120
    [end of output]
```

## How Has This Been Tested

I only have the capability to test this change on my current windows machine - building works fine on a linux VM I tried. 

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
