### PR TITLE
Update build_wheel.sh to properly use created conda environment

### DIFF
--- a/build_scripts/build_wheel.sh
+++ b/build_scripts/build_wheel.sh
@@ -124,7 +124,7 @@ for PYTHON_VERSION in 3.10; do
         /bin/bash ~/miniconda.sh -b -p /opt/conda
     ENV PATH \$CONDA_DIR/bin:\$PATH
     RUN conda create --name theseus python=${PYTHON_VERSION}
-    RUN source activate theseus
+    ENV PATH \$CONDA_DIR/envs/theseus/bin:\$PATH
 
     # --- Install torch
     ENV CUDA_HOME /usr/local/cuda-${CUDA_VERSION}


### PR DESCRIPTION
## Motivation and Context

This PR tries to fix a bug in `build_wheel.sh` that causes the theseus conda environment not to be properly used during the build stage

* **Original bug report**: #554 
* **Fix**: Updated PATH env so both `pip` and `python3` come from the theseus conda environment.

## How Has This Been Tested

This is a small fix. Use `which pip` and `which python3` during the build stage to verify. These executables should have `/opt/conda/envs/theseus/bin` as a path prefix.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
