### PR TITLE
Modify Objective::_erase_function_variables(...) to also delete varia…

### DIFF
--- a/tests/theseus_tests/core/test_objective.py
+++ b/tests/theseus_tests/core/test_objective.py
@@ -547,3 +547,18 @@ def test_to_dtype():
                 assert var.dtype == dtype
             for aux in cf.aux_vars:
                 assert aux.dtype == dtype
+
+def test_cost_delete_and_add():
+    x = th.Variable(torch.zeros(1), name="x")
+    y = th.Variable(torch.zeros(1), name="y")
+
+    def error_fn(optim_vars, aux_vars):
+        return 0
+
+    objective = th.Objective()
+    cost_function = th.AutoDiffCostFunction([x], error_fn, 1, aux_vars=[y], cost_weight=th.ScaleCostWeight(1.0))
+    
+    # Add a cost function, erase it, and add it again to make sure we don't have any bugs.
+    objective.add(cost_function)
+    objective.erase(cost_function.name)
+    objective.add(cost_function)

--- a/theseus/core/objective.py
+++ b/theseus/core/objective.py
@@ -408,6 +408,7 @@ class Objective:
             del self_var_to_fn_map[variable][cost_fn_idx]
             # if the variable has no other functions, remove it also
             if not self_var_to_fn_map[variable]:
+                del self._all_variables[variable.name]
                 del self_var_to_fn_map[variable]
                 del self_vars_of_this_type[variable.name]
 


### PR DESCRIPTION
…ble name from _all_variables.

Not deleting a variable name in _all_variables that is no longer used causes crashes when you try to add a CostFunction that includes the variable name again.

## Motivation and Context

If you delete enough CostFunctions where the underlying variables are deleted and then add another CostFunction that uses the same variable, the [following check passes](https://github.com/facebookresearch/theseus/blob/9a117fd02867c5007c6686e342630f110e488c65/theseus/core/objective.py#L186), causing [this statement](https://github.com/facebookresearch/theseus/blob/9a117fd02867c5007c6686e342630f110e488c65/theseus/core/objective.py#L206C12-L206C12) to crash due to [this statement](https://github.com/facebookresearch/theseus/blob/9a117fd02867c5007c6686e342630f110e488c65/theseus/core/objective.py#L196) not being executed.

## How Has This Been Tested

Ran tests and optimizations in own code.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
