### PR TITLE
Faster log map implementation

### DIFF
--- a/evaluations/time_local_cost_backward.py
+++ b/evaluations/time_local_cost_backward.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
 
     for p in [True, False]:
         set_global_params({"_allow_passthrough_ops": p})
+        set_global_params({"_faster_log_maps": p})
         for i in tqdm.tqdm(range(args.reps + args.w)):
             run(
                 args.g,

--- a/evaluations/time_local_cost_backward.py
+++ b/evaluations/time_local_cost_backward.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             label = f"b{backward:1d}-p{p:1d}"
             set_lie_global_params({"_allow_passthrough_ops": p})
             set_lie_global_params({"_faster_log_maps": p})
-            set_th_global_params({"fast_approx_log_maps": p})
+            set_th_global_params({"fast_approx_local_jacobians": p})
             for i in tqdm.tqdm(range(args.reps + args.w)):
                 run(
                     backward,

--- a/evaluations/time_local_cost_backward.py
+++ b/evaluations/time_local_cost_backward.py
@@ -1,17 +1,26 @@
 import argparse
 
+import numpy as np
 import theseus as th
 import torch
+import tqdm
 import torchlie.functional as lieF
+from torchlie.functional.lie_group import LieGroupFns
 from torchlie.global_params import set_global_params
 from theseus.utils import Timer
 
 
 def run(
-    group_type: str, dev: str, batch_size: int, rng: torch.Generator, verbose: bool
+    group_type: str,
+    dev: str,
+    batch_size: int,
+    rng: torch.Generator,
+    verbose: bool,
+    timer: Timer,
+    timer_label: str,
 ):
     theseus_cls = getattr(th, group_type)
-    lieF_cls = getattr(lieF, group_type)
+    lieF_cls: LieGroupFns = getattr(lieF, group_type)
     p = torch.nn.Parameter(lieF_cls.rand(batch_size, device=dev, generator=rng))
     adam = torch.optim.Adam([p], lr={"SO3": 0.1, "SE3": 0.01}[group_type])
     a = theseus_cls(name="a")
@@ -20,33 +29,52 @@ def run(
     )
     o = th.Objective()
     o.add(th.Local(a, b, th.ScaleCostWeight(1.0), name="d"))
-    layer = th.TheseusLayer(th.GaussNewton(o, max_iterations=3, step_size=0.1))
+    layer = th.TheseusLayer(th.LevenbergMarquardt(o, max_iterations=3, step_size=0.1))
     layer.to(dev)
+    timer.start(timer_label)
     for i in range(10):
         adam.zero_grad()
-        layer.forward(input_tensors={"a": p.clone()})
+        layer.forward(input_tensors={"a": p.clone()}, optimizer_kwargs={"damping": 0.1})
         loss = o.error_metric().sum()
         if verbose:
             print(loss.item())
         loss.backward()
         adam.step()
+    timer.end()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("reps", type=int, default=1)
-    parser.add_argument("--p", action="store_true")
-    parser.add_argument("--dev", type=str, default="cpu")
-    parser.add_argument("--v", action="store_true")
-    parser.add_argument("--g", choices=["SO3", "SE3"], default="SE3")
+    parser.add_argument("--b", type=int, default=1, help="batch size")
+    parser.add_argument("--v", action="store_true", help="verbose")
+    parser.add_argument("--g", choices=["SO3", "SE3"], default="SE3", help="group type")
+    parser.add_argument("--w", type=int, default=1, help="warmup iters")
+    parser.add_argument("--dev", type=str, default="cpu", help="device")
     args = parser.parse_args()
-    if args.p:
-        set_global_params({"_allow_passthrough_ops": True})
 
     rng = torch.Generator(device=args.dev)
     rng.manual_seed(0)
-    batch_sizes = torch.randint(1, 16, (args.reps,), device=args.dev, generator=rng)
-    with Timer(args.dev) as timer:
-        for i in range(args.reps):
-            run(args.g, args.dev, batch_sizes[i].item(), rng, args.v)
-    print(timer.elapsed_time)
+    timer = Timer(args.dev)
+    print(f"Timing device {timer.device}")
+
+    for p in [True, False]:
+        set_global_params({"_allow_passthrough_ops": p})
+        for i in tqdm.tqdm(range(args.reps + args.w)):
+            run(
+                args.g,
+                args.dev,
+                args.b,
+                rng,
+                args.v,
+                timer,
+                f"run-{p}" if i > args.w else f"warmup-{p}",
+            )
+    time_stats = timer.stats()
+    results = {}
+    for k, v in time_stats.items():
+        print([f"{x:.3f}" for x in v])
+        results[k] = (np.mean(v), np.std(v) / np.sqrt(len(v)))
+        print(k, results[k])
+    print(1 - results["run-True"][0] / results["run-False"][0])
+    print("-----------------------------")

--- a/evaluations/time_local_cost_backward.py
+++ b/evaluations/time_local_cost_backward.py
@@ -1,0 +1,52 @@
+import argparse
+
+import theseus as th
+import torch
+import torchlie.functional as lieF
+from torchlie.global_params import set_global_params
+from theseus.utils import Timer
+
+
+def run(
+    group_type: str, dev: str, batch_size: int, rng: torch.Generator, verbose: bool
+):
+    theseus_cls = getattr(th, group_type)
+    lieF_cls = getattr(lieF, group_type)
+    p = torch.nn.Parameter(lieF_cls.rand(batch_size, device=dev, generator=rng))
+    adam = torch.optim.Adam([p], lr={"SO3": 0.1, "SE3": 0.01}[group_type])
+    a = theseus_cls(name="a")
+    b = theseus_cls(
+        tensor=lieF_cls.rand(batch_size, device=dev, generator=rng), name="b"
+    )
+    o = th.Objective()
+    o.add(th.Local(a, b, th.ScaleCostWeight(1.0), name="d"))
+    layer = th.TheseusLayer(th.GaussNewton(o, max_iterations=3, step_size=0.1))
+    layer.to(dev)
+    for i in range(10):
+        adam.zero_grad()
+        layer.forward(input_tensors={"a": p.clone()})
+        loss = o.error_metric().sum()
+        if verbose:
+            print(loss.item())
+        loss.backward()
+        adam.step()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("reps", type=int, default=1)
+    parser.add_argument("--p", action="store_true")
+    parser.add_argument("--dev", type=str, default="cpu")
+    parser.add_argument("--v", action="store_true")
+    parser.add_argument("--g", choices=["SO3", "SE3"], default="SE3")
+    args = parser.parse_args()
+    if args.p:
+        set_global_params({"_allow_passthrough_ops": True})
+
+    rng = torch.Generator(device=args.dev)
+    rng.manual_seed(0)
+    batch_sizes = torch.randint(1, 16, (args.reps,), device=args.dev, generator=rng)
+    with Timer(args.dev) as timer:
+        for i in range(args.reps):
+            run(args.g, args.dev, batch_sizes[i].item(), rng, args.v)
+    print(timer.elapsed_time)

--- a/examples/se2_planning.py
+++ b/examples/se2_planning.py
@@ -17,7 +17,7 @@ import theseus.utils.examples as theg
 
 torch.set_default_dtype(torch.double)
 
-device = "cuda:0" if torch.cuda.is_available else "cpu"
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
 torch.random.manual_seed(1)
 random.seed(1)
 np.random.seed(1)

--- a/tests/torchlie_tests/functional/common.py
+++ b/tests/torchlie_tests/functional/common.py
@@ -66,7 +66,7 @@ def get_test_cfg(op_name, dtype, dim, data_shape, module=None):
 #
 # `batch_size` can be a tuple.
 def sample_inputs(input_types, batch_size, dtype, rng):
-    dev = "cuda:0" if torch.cuda.is_available else "cpu"
+    dev = "cuda:0" if torch.cuda.is_available() else "cpu"
     if isinstance(batch_size, int):
         batch_size = (batch_size,)
 

--- a/tests/torchlie_tests/functional/common.py
+++ b/tests/torchlie_tests/functional/common.py
@@ -6,6 +6,8 @@ from functools import reduce
 
 import torch
 
+from torchlie.global_params import set_global_params
+
 
 BATCH_SIZES_TO_TEST = [1, 20, (1, 2), (3, 4, 5), tuple()]
 TEST_EPS = 5e-7
@@ -324,3 +326,19 @@ def check_left_project_broadcasting(
                 torch.autograd.gradcheck(
                     lie_group_fns.left_project, (g, t, out_dim), raise_exception=True
                 )
+
+
+def check_log_map_passt(lie_group_fns, impl_module):
+    set_global_params({"_allow_passthrough_ops": True})
+    group = lie_group_fns.rand(
+        4, device="cuda:0" if torch.cuda.is_available() else "cpu", requires_grad=True
+    )
+    jlist = []
+    log_map_pt = lie_group_fns.log(group, jacobians=jlist)
+    grad_pt = torch.autograd.grad(log_map_pt.sum(), group)
+    log_map_ref = impl_module._log_autograd_fn(group)
+    jac_ref = impl_module._jlog_impl(group)[0][0]
+    grad_ref = torch.autograd.grad(log_map_ref.sum(), group)
+    torch.testing.assert_close(log_map_pt, log_map_ref)
+    torch.testing.assert_close(jlist[0], jac_ref)
+    torch.testing.assert_close(grad_pt, grad_ref)

--- a/tests/torchlie_tests/functional/test_se3.py
+++ b/tests/torchlie_tests/functional/test_se3.py
@@ -18,6 +18,7 @@ from .common import (
     check_lie_group_function,
     check_jacrev_binary,
     check_jacrev_unary,
+    check_log_map_passt,
     run_test_op,
 )
 
@@ -43,7 +44,7 @@ from .common import (
 @pytest.mark.parametrize("batch_size", BATCH_SIZES_TO_TEST)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_op(op_name, batch_size, dtype):
-    rng = torch.Generator()
+    rng = torch.Generator(device="cuda:0" if torch.cuda.is_available() else "cpu")
     rng.manual_seed(0)
     run_test_op(op_name, batch_size, dtype, rng, 6, (3, 4), se3_impl)
 
@@ -101,3 +102,7 @@ def test_left_project_broadcasting():
     rng.manual_seed(0)
     batch_sizes = [tuple(), (1, 2), (1, 1, 2), (2, 1), (2, 2), (2, 2, 2)]
     check_left_project_broadcasting(SE3, batch_sizes, [0, 1, 2], (3, 4), rng)
+
+
+def test_log_map_passt():
+    check_log_map_passt(SE3, se3_impl)

--- a/tests/torchlie_tests/functional/test_so3.py
+++ b/tests/torchlie_tests/functional/test_so3.py
@@ -8,8 +8,8 @@ import pytest
 import torch
 
 import torchlie.functional.so3_impl as so3_impl
-from torchlie.global_params import set_global_params
 from torchlie.functional import SO3
+from torchlie.global_params import set_global_params
 
 from .common import (
     BATCH_SIZES_TO_TEST,
@@ -19,6 +19,7 @@ from .common import (
     check_lie_group_function,
     check_jacrev_binary,
     check_jacrev_unary,
+    check_log_map_passt,
     run_test_op,
 )
 
@@ -103,3 +104,7 @@ def test_left_project_broadcasting():
     rng.manual_seed(0)
     batch_sizes = [tuple(), (1, 2), (1, 1, 2), (2, 1), (2, 2), (2, 2, 2)]
     check_left_project_broadcasting(SO3, batch_sizes, [0, 1, 2], (3, 3), rng)
+
+
+def test_log_map_passt():
+    check_log_map_passt(SO3, so3_impl)

--- a/tests/torchlie_tests/functional/test_so3.py
+++ b/tests/torchlie_tests/functional/test_so3.py
@@ -8,8 +8,8 @@ import pytest
 import torch
 
 import torchlie.functional.so3_impl as so3_impl
+from torchlie.global_params import set_global_params
 from torchlie.functional import SO3
-
 
 from .common import (
     BATCH_SIZES_TO_TEST,
@@ -45,7 +45,8 @@ from .common import (
 @pytest.mark.parametrize("batch_size", BATCH_SIZES_TO_TEST)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_op(op_name, batch_size, dtype):
-    rng = torch.Generator()
+    set_global_params({"_allow_passthrough_ops": True})
+    rng = torch.Generator(device="cuda:0" if torch.cuda.is_available() else "cpu")
     rng.manual_seed(0)
     run_test_op(op_name, batch_size, dtype, rng, 3, (3, 3), so3_impl)
 

--- a/tests/torchlie_tests/functional/test_so3.py
+++ b/tests/torchlie_tests/functional/test_so3.py
@@ -45,7 +45,7 @@ from .common import (
 @pytest.mark.parametrize("batch_size", BATCH_SIZES_TO_TEST)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_op(op_name, batch_size, dtype):
-    set_global_params({"_allow_passthrough_ops": True})
+    set_global_params({"_faster_log_maps": True})
     rng = torch.Generator(device="cuda:0" if torch.cuda.is_available() else "cpu")
     rng.manual_seed(0)
     run_test_op(op_name, batch_size, dtype, rng, 3, (3, 3), so3_impl)

--- a/theseus/_version.py
+++ b/theseus/_version.py
@@ -33,4 +33,4 @@ if lt_version(torch.__version__, "2.0.0"):
         FutureWarning,
     )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2.dev0"

--- a/theseus/embodied/misc/local_cost_fn.py
+++ b/theseus/embodied/misc/local_cost_fn.py
@@ -40,7 +40,7 @@ class Local(CostFunction):
         return self.target.local(self.var)
 
     def jacobians(self) -> Tuple[List[torch.Tensor], torch.Tensor]:
-        if _THESEUS_GLOBAL_PARAMS.fast_approx_log_maps:
+        if _THESEUS_GLOBAL_PARAMS.fast_approx_local_jacobians:
             if (
                 self._jac_cache is not None
                 and self._jac_cache.shape[0] == self.var.shape[0]

--- a/theseus/global_params.py
+++ b/theseus/global_params.py
@@ -28,6 +28,7 @@ class _TheseusGlobalParams:
     so2_norm_eps_float64: float = 0
     so2_matrix_eps_float64: float = 0
     se2_near_zero_eps_float64: float = 0
+    fast_approx_log_maps: bool = False
 
     def __init__(self):
         self.reset()
@@ -50,6 +51,7 @@ class _TheseusGlobalParams:
         self.so2_matrix_eps_float64 = 4e-7
         self.se2_near_zero_eps_float64 = 1e-6
         self.se2_d_near_zero_eps_float64 = 1e-3
+        self.fast_approx_log_maps = False
 
 
 _THESEUS_GLOBAL_PARAMS = _TheseusGlobalParams()

--- a/theseus/global_params.py
+++ b/theseus/global_params.py
@@ -28,7 +28,7 @@ class _TheseusGlobalParams:
     so2_norm_eps_float64: float = 0
     so2_matrix_eps_float64: float = 0
     se2_near_zero_eps_float64: float = 0
-    fast_approx_log_maps: bool = False
+    fast_approx_local_jacobians: bool = False
 
     def __init__(self):
         self.reset()
@@ -51,7 +51,7 @@ class _TheseusGlobalParams:
         self.so2_matrix_eps_float64 = 4e-7
         self.se2_near_zero_eps_float64 = 1e-6
         self.se2_d_near_zero_eps_float64 = 1e-3
-        self.fast_approx_log_maps = False
+        self.fast_approx_local_jacobians = False
 
 
 _THESEUS_GLOBAL_PARAMS = _TheseusGlobalParams()

--- a/torchlie/torchlie/__init__.py
+++ b/torchlie/torchlie/__init__.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-__version__ = "0.1.0"
+__version__ = "0.1.1.dev0"
 
 from .global_params import reset_global_params, set_global_params
 from .lie_tensor import (  # usort: skip

--- a/torchlie/torchlie/functional/se3_impl.py
+++ b/torchlie/torchlie/functional/se3_impl.py
@@ -484,6 +484,16 @@ def _jlog_impl(group: torch.Tensor) -> Tuple[List[torch.Tensor], torch.Tensor]:
     return [jac], tangent_vector
 
 
+def _log_backward(
+    group: torch.Tensor, jacobian: torch.Tensor, grad_output: torch.Tensor
+) -> torch.Tensor:
+    jacobian[..., 3:] *= 0.5
+    temp: torch.Tensor = lift(
+        (jacobian.transpose(-1, -2) @ grad_output.unsqueeze(-1)).squeeze(-1)
+    )
+    return group[..., :3] @ temp
+
+
 class Log(lie_group.UnaryOperator):
     @classmethod
     def _forward_impl(cls, group):
@@ -499,17 +509,21 @@ class Log(lie_group.UnaryOperator):
     @classmethod
     def backward(cls, ctx, grad_output):
         group: torch.Tensor = ctx.saved_tensors[1]
-        jacobians = _jlog_impl(group)[0][0]
-        jacobians[..., 3:] *= 0.5
-        temp: torch.Tensor = lift(
-            (jacobians.transpose(-1, -2) @ grad_output.unsqueeze(-1)).squeeze(-1)
-        )
-        return group[..., :3] @ temp
+        return _log_backward(group, _jlog_impl(group)[0][0], grad_output)
+
+
+class _LogPassthroughWrapper(lie_group._UnaryPassthroughFn):
+    @classmethod
+    def _backward_impl(
+        cls, group: torch.Tensor, jacobian: torch.Tensor, grad_output: torch.Tensor
+    ) -> torch.Tensor:
+        return _log_backward(group, jacobian, grad_output)
 
 
 # TODO: Implement analytic backward for _jlog_impl
 _log_autograd_fn = Log.apply
 _jlog_autograd_fn = _jlog_impl
+_log_passthrough_fn = _LogPassthroughWrapper.apply
 
 
 # -----------------------------------------------------------------------------

--- a/torchlie/torchlie/functional/se3_impl.py
+++ b/torchlie/torchlie/functional/se3_impl.py
@@ -487,11 +487,10 @@ def _jlog_impl(group: torch.Tensor) -> Tuple[List[torch.Tensor], torch.Tensor]:
 def _log_backward(
     group: torch.Tensor, jacobian: torch.Tensor, grad_output: torch.Tensor
 ) -> torch.Tensor:
-    jacobian[..., 3:] *= 0.5
-    temp: torch.Tensor = lift(
-        (jacobian.transpose(-1, -2) @ grad_output.unsqueeze(-1)).squeeze(-1)
-    )
-    return group[..., :3] @ temp
+    jac_by_g = (jacobian.transpose(-1, -2) @ grad_output.unsqueeze(-1)).squeeze(-1)
+    jac_by_g[..., 3:] *= 0.5
+    temp2: torch.Tensor = lift(jac_by_g)
+    return group[..., :3] @ temp2
 
 
 class Log(lie_group.UnaryOperator):

--- a/torchlie/torchlie/functional/so3_impl.py
+++ b/torchlie/torchlie/functional/so3_impl.py
@@ -364,7 +364,7 @@ if torch.cuda.is_available():
 
 
 def _sine_axis_fn(group: torch.Tensor, size: torch.Size) -> torch.Tensor:
-    if LIE_PARAMS._allow_passthrough_ops:
+    if LIE_PARAMS._faster_log_maps:
         if group.is_cuda:
             g_minus_gt = 0.5 * (group.adjoint() - group)
             upper_idx = _UPPER_IDX_3x3_CUDA[str(group.device)]

--- a/torchlie/torchlie/functional/so3_impl.py
+++ b/torchlie/torchlie/functional/so3_impl.py
@@ -361,9 +361,10 @@ _jexp_autograd_fn = _jexp_impl
 def _log_impl_helper(group: torch.Tensor):
     size = get_group_size(group)
     sine_axis = group.new_zeros(*size, 3)
-    sine_axis[..., 0] = 0.5 * (group[..., 2, 1] - group[..., 1, 2])
-    sine_axis[..., 1] = 0.5 * (group[..., 0, 2] - group[..., 2, 0])
-    sine_axis[..., 2] = 0.5 * (group[..., 1, 0] - group[..., 0, 1])
+    sine_axis[..., 0] = group[..., 2, 1] - group[..., 1, 2]
+    sine_axis[..., 1] = group[..., 0, 2] - group[..., 2, 0]
+    sine_axis[..., 2] = group[..., 1, 0] - group[..., 0, 1]
+    sine_axis *= 0.5
     cosine = 0.5 * (group.diagonal(dim1=-1, dim2=-2).sum(dim=-1) - 1)
     sine = sine_axis.norm(dim=-1)
     theta = torch.atan2(sine, cosine)

--- a/torchlie/torchlie/global_params.py
+++ b/torchlie/torchlie/global_params.py
@@ -31,6 +31,7 @@ class _TorchLieGlobalParams:
     so3_hat_eps_float64: float = 0
     se3_hat_eps_float64: float = 0
     _allow_passthrough_ops: bool = False
+    _faster_log_maps: bool = False
 
     def __init__(self):
         self.reset()

--- a/torchlie/torchlie/global_params.py
+++ b/torchlie/torchlie/global_params.py
@@ -30,6 +30,7 @@ class _TorchLieGlobalParams:
     so3_quat_eps_float64: float = 0
     so3_hat_eps_float64: float = 0
     se3_hat_eps_float64: float = 0
+    _allow_passthrough_ops: bool = False
 
     def __init__(self):
         self.reset()

--- a/tutorials/05_differentiable_motion_planning.ipynb
+++ b/tutorials/05_differentiable_motion_planning.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "torch.set_default_dtype(torch.double)\n",
     "\n",
-    "device = \"cuda:0\" if torch.cuda.is_available else \"cpu\"\n",
+    "device = \"cuda:0\" if torch.cuda.is_available() else \"cpu\"\n",
     "torch.random.manual_seed(1)\n",
     "random.seed(1)\n",
     "np.random.seed(1)\n",


### PR DESCRIPTION
The current autograd operators in `torchlie.functional` result in duplicated computation for function calls such as 
```python
res = torchlie.functional.SO3.log(g, jacobians=jlist)
```
because these are computed as follows:

```python
jac, _= _jlog_impl(group)
res = _log_autograd_fn(group) # repeats all the computation done in `_op_impl`
return res, jac
``` 

This PR adds a wrapper that reuses the computation, while preserving the custom backward implementation, as follows

```python
jac, res_value = _jlog_impl(group)
res_tensor = _log_passthrough_fn(group, res_value, jac[0])
return res_tensor, jac
```

Benchmarking with [this script](https://github.com/facebookresearch/theseus/blob/lep.faster_log_map/evaluations/time_local_cost_backward.py) shows improvements of 15-23% runtime when backpropagating through local cost functions in Theseus.  I haven't written any dedicated unit tests, but both versions result in the same loss history in the script above, so things look correct. 