### PR TITLE
Improves to Timer and Profiler utils

### DIFF
--- a/tests/theseus_tests/utils/test_utils.py
+++ b/tests/theseus_tests/utils/test_utils.py
@@ -171,6 +171,7 @@ def test_jacobians_check():
 
 
 def test_timer():
+    # Check different ways of instantiating work correctly
     with thutils.Timer("cpu") as timer:
         torch.randn(1)
     assert timer.elapsed_time > 0
@@ -189,11 +190,21 @@ def test_timer():
         torch.randn(1)
     assert timer.elapsed_time == 0
 
+    # Checking that deactivate keyword works correctly
     timer = thutils.Timer("cpu")
+    with timer("randn", deactivate=True):
+        torch.randn(1)
+    assert timer.elapsed_time == 0
+    timer.start("randn", deactivate=True)
+    torch.randn(1)
+    timer.end()
+    assert timer.elapsed_time == 0
+    # Checking that stats accumulation works correctly
     with timer("randn"):
         torch.randn(1)
-    with timer("randn"):
-        torch.randn(1)
+    timer.start("randn")
+    torch.randn(1)
+    timer.end()
     with timer("mult"):
         torch.ones(1) * torch.zeros(1)
     stats = timer.stats()

--- a/tests/theseus_tests/utils/test_utils.py
+++ b/tests/theseus_tests/utils/test_utils.py
@@ -168,3 +168,35 @@ def test_jacobians_check():
 
     cf = th.eb.DoubleIntegrator(se3s[0], th.Vector(6), se3s[1], th.Vector(6), 1.0, w)
     thutils.check_jacobians(cf, 1)
+
+
+def test_timer():
+    with thutils.Timer("cpu") as timer:
+        torch.randn(1)
+    assert timer.elapsed_time > 0
+
+    with thutils.Timer("cpu", active=False) as timer:
+        torch.randn(1)
+    assert timer.elapsed_time == 0
+
+    timer = thutils.Timer("cpu")
+    with timer:
+        torch.randn(1)
+    assert timer.elapsed_time > 0
+
+    timer = thutils.Timer("cpu", active=False)
+    with timer:
+        torch.randn(1)
+    assert timer.elapsed_time == 0
+
+    timer = thutils.Timer("cpu")
+    with timer("randn"):
+        torch.randn(1)
+    with timer("randn"):
+        torch.randn(1)
+    with timer("mult"):
+        torch.ones(1) * torch.zeros(1)
+    stats = timer.stats()
+    assert "randn" in stats and "mult" in stats
+    assert len(stats["randn"]) == 2
+    assert len(stats["mult"]) == 1

--- a/theseus/utils/utils.py
+++ b/theseus/utils/utils.py
@@ -285,3 +285,11 @@ class Profiler:
             ps = pstats.Stats(self.c_profiler, stream=s).sort_stats(sortby)
             ps.print_stats()
             print(s.getvalue())
+
+    def create_stats(self):
+        if self.active:
+            self.c_profiler.create_stats()
+
+    def dump_stats(self, filename: str):
+        if self.active:
+            self.c_profiler.dump_stats(filename)

--- a/theseus/utils/utils.py
+++ b/theseus/utils/utils.py
@@ -251,10 +251,11 @@ class Timer:
             self._stats[self._caller].append(self.elapsed_time)
 
     def __call__(self, caller: Optional[str] = None) -> "Timer":
-        self.start(caller=caller)
+        self._caller = caller
         return self
 
     def __enter__(self) -> "Timer":
+        self.start(caller=self._caller)
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:


### PR DESCRIPTION
The timer now has the option of labeling timing runs, and collect history of times per label. Can also be called with `start()` and `end()` methods, without using as a context manager.

The profiler has now methods to to compile the statistics and dump results to a file. 